### PR TITLE
update download code to use entrez-direct

### DIFF
--- a/machine/wort-web/download_daily_sra.sh
+++ b/machine/wort-web/download_daily_sra.sh
@@ -10,9 +10,14 @@ day_plain=$(date -d $DAY_TO_CHECK +%Y%m%d)
 output=outputs/${day_plain}.csv
 output_metagenomes=outputs_metagenomes/${day_plain}.csv
 
-wget -O ${output} 'http://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?save=efetch&db=sra&rettype=runinfo&term=("'${day_slash}'"[PDAT] : "'${day_slash}'"[PDAT]) AND "biomol dna"[Properties] NOT amplicon[All Fields] NOT "Metazoa"[orgn:__txid33208] NOT "Streptophyta"[orgn:__txid35493] NOT "metagenomic"[Source]'
+# Perform the EDirect search for genomic samples
+esearch -db sra -query "(${day_slash}[PDAT] : 3000[PDAT]) AND biomol dna[Properties] NOT amplicon[All Fields] NOT Metazoa[orgn:__txid33208] NOT Streptophyta[orgn:__txid35493] NOT METAGENOMIC[Source]" | efetch -format runinfo -mode text > ${output}
 
-wget -O ${output_metagenomes} 'http://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?save=efetch&db=sra&rettype=runinfo&term=("'${day_slash}'"[PDAT] : "'${day_slash}'"[PDAT]) NOT amplicon[All Fields] AND "METAGENOMIC"[Source]'
+# Perform the EDirect search for metagenomic samples
+esearch -db sra -query "(${day_slash}[PDAT] : 3000[PDAT]) NOT amplicon[All Fields] AND METAGENOMIC[Source]" | efetch -format runinfo -mode text > ${output_metagenomes}
+
+echo "DNA samples saved to: ${output}"
+echo "Metagenomic samples saved to: ${output_metagenomes}"
 
 /usr/local/bin/docker-compose exec -T web flask shell -c "%run -i machine/wort-web/add_dataset_info.py machine/wort-web/${output}"
 /home/ubuntu/.local/bin/pipenv run python submit.py ${output} | tee logs/`date +%Y%m%d_%H%M`.submitted


### PR DESCRIPTION
@luizirber - here's the `edirect` code we chatted about a few times, but actually in the right place, and verified that it downloads data that ~looks right.

Not sure how helpful this is, since I seem to recall there were a few other things that needed work.

I installed `entrez-direct` via conda:
```
name: edirect
channels:
  - conda-forge
  - bioconda
  - defaults
dependencies:
  - entrez-direct>=16,<17
```