### PR TITLE
fix: don't upload empty sigs, raise exception with more details for debug later

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/prefix-dev/pixi:0.36.0 AS build
+FROM ghcr.io/prefix-dev/pixi:0.40.3 AS build
 
 COPY . /app
 WORKDIR /app

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,4 +1,4 @@
-version: 5
+version: 6
 environments:
   default:
     channels:
@@ -455,6 +455,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cachelib-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.5.0-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
@@ -479,6 +480,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.9-py310h275853b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycurl-7.45.3-py310h80730c7_1.conda
@@ -498,6 +500,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       - pypi: https://files.pythonhosted.org/packages/df/ed/c884465c33c25451e4a5cd4acad154c29e5341e3214e220e7f3478aa4b0d/alembic-1.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/f0/8e5be5d5e0653d9e1d02b1144efa33ff7d2963dfad07049e02c0fa9b2e8d/amqp-5.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/8d/6e9fdeeab04d803abc5a715175f87e88893934d5590595eacff23ca12b07/billiard-4.2.0-py3-none-any.whl
@@ -512,16 +515,21 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/e6/851b3d7688115b176eb5d3e45055d1dc5b2b91708007064a38b0e93813ed/connexion-2.14.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/1a/8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310/Flask-2.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/01/587023575286236f95d2ab8a826c320375ed5ea2102bb103ed89704ffa6b/Flask_Migrate-4.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/47/c0ad5f8fd6e9208b12018706c0da45fba3ad3042faffcdc5ae96114dc8ba/flask_shell_ipython-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/01/97ecc5174d35ec73d049bbea80b576e808e74dbd61af3a9aab6401515504/flask_wtf-1.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/2f/64628f6ae48e05f585e0eb3fb7399b52e240ef99f602107b445bf6be23ef/greenlet-3.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/57/ef12725f8af19920db1d8f2eaee44ebbaee6d9fdcf853be5db76bfdb9ce6/ipython-8.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/18/0c62b011d64158c2420594002f58b3ad30a8e982bf8e6b4f078df9e95b9b/jsonschema_spec-0.1.6-py3-none-any.whl
@@ -529,9 +537,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8b/fc/83711d743fb5aaca5747bbf225fe3b5cbe085c7f6c115856b5cce80f3224/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/03/62/70f5a0c2dd208f9f3f2f9afd103aec42ee4d9ad2401d78342f75e9b8da36/Mako-1.3.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/94/9cb35371ac834d56ba2bd8870cdab1be25dc664f3a7387f8057ac091916b/openapi_schema_validator-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/68/05df6b11a082ee09b8b5319b3c8aeda58b8d3bccf89f201c45e8fe8a91d2/openapi_spec_validator-0.5.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/0a/acfb251ba01009d3053f04f4661e96abf9d485266b04a0a4deebc702d9cb/pathable-0.4.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/b7/64a125c488243965b7c5118352e47c6f89df95b4ac306d31cee409153d57/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/7f/21a09f8c9f5db6f5e24432f7a0f916ca386025d74e4da6d0f5164aa9a78a/redis-4.5.5-py3-none-any.whl
@@ -540,7 +554,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/17/a3b666f5ef9543cfd3c661d39d1e193abb9649d0cfbbfee3cf3b51d5af02/s3transfer-0.6.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/9e/9298785949269c8930e1fd3707b960da6e1a95a2442b747b8f8cca4578cb/sentry_sdk-2.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/90/0ce8c76cd2ef8a5e0838d61d6648a1193859e1990bc1d65c8b0fd1f77ca8/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl
@@ -555,6 +571,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cachelib-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.5.0-h4e8248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
@@ -579,6 +596,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psycopg2-2.9.9-py310h729f94d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pycurl-7.45.3-py310h00deb75_1.conda
@@ -598,6 +616,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
       - pypi: https://files.pythonhosted.org/packages/df/ed/c884465c33c25451e4a5cd4acad154c29e5341e3214e220e7f3478aa4b0d/alembic-1.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/f0/8e5be5d5e0653d9e1d02b1144efa33ff7d2963dfad07049e02c0fa9b2e8d/amqp-5.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/8d/6e9fdeeab04d803abc5a715175f87e88893934d5590595eacff23ca12b07/billiard-4.2.0-py3-none-any.whl
@@ -612,16 +631,21 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/e6/851b3d7688115b176eb5d3e45055d1dc5b2b91708007064a38b0e93813ed/connexion-2.14.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/1a/8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310/Flask-2.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/01/587023575286236f95d2ab8a826c320375ed5ea2102bb103ed89704ffa6b/Flask_Migrate-4.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/47/c0ad5f8fd6e9208b12018706c0da45fba3ad3042faffcdc5ae96114dc8ba/flask_shell_ipython-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/01/97ecc5174d35ec73d049bbea80b576e808e74dbd61af3a9aab6401515504/flask_wtf-1.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/d6/408ad9603339db28ce334021b1403dfcfbcb7501a435d49698408d928de7/greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/57/ef12725f8af19920db1d8f2eaee44ebbaee6d9fdcf853be5db76bfdb9ce6/ipython-8.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/18/0c62b011d64158c2420594002f58b3ad30a8e982bf8e6b4f078df9e95b9b/jsonschema_spec-0.1.6-py3-none-any.whl
@@ -629,9 +653,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4a/0d/b325461e43dde8d7644e9b9e9dd57f2a4af472b588c51ccbc92778e60ea4/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/03/62/70f5a0c2dd208f9f3f2f9afd103aec42ee4d9ad2401d78342f75e9b8da36/Mako-1.3.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/94/9cb35371ac834d56ba2bd8870cdab1be25dc664f3a7387f8057ac091916b/openapi_schema_validator-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/68/05df6b11a082ee09b8b5319b3c8aeda58b8d3bccf89f201c45e8fe8a91d2/openapi_spec_validator-0.5.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/0a/acfb251ba01009d3053f04f4661e96abf9d485266b04a0a4deebc702d9cb/pathable-0.4.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/4f/8342079ea331031ef9ed57edd312a9ad283bcc8adfaf268931ae356a09a6/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/55e4f21db1f72eaef092015d9017c11510e7e6301c62a6cfee91295d13c6/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/7f/21a09f8c9f5db6f5e24432f7a0f916ca386025d74e4da6d0f5164aa9a78a/redis-4.5.5-py3-none-any.whl
@@ -640,7 +670,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/17/a3b666f5ef9543cfd3c661d39d1e193abb9649d0cfbbfee3cf3b51d5af02/s3transfer-0.6.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/9e/9298785949269c8930e1fd3707b960da6e1a95a2442b747b8f8cca4578cb/sentry_sdk-2.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/ab/69df806d3d695ac3e6ad1af884ddfa80ef8a9d2c73d49279464c989a55ac/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl
@@ -671,6 +703,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.5.0-hca28451_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecation-2.1.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py310h5b4e0ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-70.1-h27087fc_0.tar.bz2
@@ -756,6 +789,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py310hf73ecf8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.9-py310h275853b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
@@ -787,6 +821,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       - pypi: https://files.pythonhosted.org/packages/df/ed/c884465c33c25451e4a5cd4acad154c29e5341e3214e220e7f3478aa4b0d/alembic-1.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/f0/8e5be5d5e0653d9e1d02b1144efa33ff7d2963dfad07049e02c0fa9b2e8d/amqp-5.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/8d/6e9fdeeab04d803abc5a715175f87e88893934d5590595eacff23ca12b07/billiard-4.2.0-py3-none-any.whl
@@ -801,16 +836,21 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/e6/851b3d7688115b176eb5d3e45055d1dc5b2b91708007064a38b0e93813ed/connexion-2.14.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/1a/8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310/Flask-2.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/01/587023575286236f95d2ab8a826c320375ed5ea2102bb103ed89704ffa6b/Flask_Migrate-4.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/47/c0ad5f8fd6e9208b12018706c0da45fba3ad3042faffcdc5ae96114dc8ba/flask_shell_ipython-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/01/97ecc5174d35ec73d049bbea80b576e808e74dbd61af3a9aab6401515504/flask_wtf-1.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/2f/64628f6ae48e05f585e0eb3fb7399b52e240ef99f602107b445bf6be23ef/greenlet-3.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/57/ef12725f8af19920db1d8f2eaee44ebbaee6d9fdcf853be5db76bfdb9ce6/ipython-8.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/18/0c62b011d64158c2420594002f58b3ad30a8e982bf8e6b4f078df9e95b9b/jsonschema_spec-0.1.6-py3-none-any.whl
@@ -818,9 +858,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8b/fc/83711d743fb5aaca5747bbf225fe3b5cbe085c7f6c115856b5cce80f3224/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/03/62/70f5a0c2dd208f9f3f2f9afd103aec42ee4d9ad2401d78342f75e9b8da36/Mako-1.3.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/94/9cb35371ac834d56ba2bd8870cdab1be25dc664f3a7387f8057ac091916b/openapi_schema_validator-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/68/05df6b11a082ee09b8b5319b3c8aeda58b8d3bccf89f201c45e8fe8a91d2/openapi_spec_validator-0.5.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/0a/acfb251ba01009d3053f04f4661e96abf9d485266b04a0a4deebc702d9cb/pathable-0.4.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/b7/64a125c488243965b7c5118352e47c6f89df95b4ac306d31cee409153d57/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/7f/21a09f8c9f5db6f5e24432f7a0f916ca386025d74e4da6d0f5164aa9a78a/redis-4.5.5-py3-none-any.whl
@@ -829,7 +875,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/17/a3b666f5ef9543cfd3c661d39d1e193abb9649d0cfbbfee3cf3b51d5af02/s3transfer-0.6.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/9e/9298785949269c8930e1fd3707b960da6e1a95a2442b747b8f8cca4578cb/sentry_sdk-2.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/90/0ce8c76cd2ef8a5e0838d61d6648a1193859e1990bc1d65c8b0fd1f77ca8/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl
@@ -852,6 +900,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.5.0-h4e8248e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecation-2.1.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.53.1-py310hb52b2da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
@@ -901,6 +950,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-10.4.0-py310h611336f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psycopg2-2.9.9-py310h729f94d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
@@ -930,6 +980,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
       - pypi: https://files.pythonhosted.org/packages/df/ed/c884465c33c25451e4a5cd4acad154c29e5341e3214e220e7f3478aa4b0d/alembic-1.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/f0/8e5be5d5e0653d9e1d02b1144efa33ff7d2963dfad07049e02c0fa9b2e8d/amqp-5.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/8d/6e9fdeeab04d803abc5a715175f87e88893934d5590595eacff23ca12b07/billiard-4.2.0-py3-none-any.whl
@@ -944,16 +995,21 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/e6/851b3d7688115b176eb5d3e45055d1dc5b2b91708007064a38b0e93813ed/connexion-2.14.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/1a/8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310/Flask-2.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/01/587023575286236f95d2ab8a826c320375ed5ea2102bb103ed89704ffa6b/Flask_Migrate-4.0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/47/c0ad5f8fd6e9208b12018706c0da45fba3ad3042faffcdc5ae96114dc8ba/flask_shell_ipython-0.5.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/01/97ecc5174d35ec73d049bbea80b576e808e74dbd61af3a9aab6401515504/flask_wtf-1.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/d6/408ad9603339db28ce334021b1403dfcfbcb7501a435d49698408d928de7/greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/57/ef12725f8af19920db1d8f2eaee44ebbaee6d9fdcf853be5db76bfdb9ce6/ipython-8.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/18/0c62b011d64158c2420594002f58b3ad30a8e982bf8e6b4f078df9e95b9b/jsonschema_spec-0.1.6-py3-none-any.whl
@@ -961,9 +1017,15 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4a/0d/b325461e43dde8d7644e9b9e9dd57f2a4af472b588c51ccbc92778e60ea4/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/03/62/70f5a0c2dd208f9f3f2f9afd103aec42ee4d9ad2401d78342f75e9b8da36/Mako-1.3.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/94/9cb35371ac834d56ba2bd8870cdab1be25dc664f3a7387f8057ac091916b/openapi_schema_validator-0.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/68/05df6b11a082ee09b8b5319b3c8aeda58b8d3bccf89f201c45e8fe8a91d2/openapi_spec_validator-0.5.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5b/0a/acfb251ba01009d3053f04f4661e96abf9d485266b04a0a4deebc702d9cb/pathable-0.4.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/4f/8342079ea331031ef9ed57edd312a9ad283bcc8adfaf268931ae356a09a6/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/26/55e4f21db1f72eaef092015d9017c11510e7e6301c62a6cfee91295d13c6/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/7f/21a09f8c9f5db6f5e24432f7a0f916ca386025d74e4da6d0f5164aa9a78a/redis-4.5.5-py3-none-any.whl
@@ -972,32 +1034,24 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/17/a3b666f5ef9543cfd3c661d39d1e193abb9649d0cfbbfee3cf3b51d5af02/s3transfer-0.6.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/9e/9298785949269c8930e1fd3707b960da6e1a95a2442b747b8f8cca4578cb/sentry_sdk-2.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/ab/69df806d3d695ac3e6ad1af884ddfa80ef8a9d2c73d49279464c989a55ac/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/f8/9da63c1617ae2a1dec2fbf6412f3a0cfe9d4ce029eccbda6e1e4258ca45f/Werkzeug-2.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/19/c3232f35e24dccfad372e9f341c4f3a1166ae7c66e4e1351a9467c921cc1/wtforms-3.1.2-py3-none-any.whl
 packages:
-- kind: conda
-  name: _libgcc_mutex
-  version: '0.1'
-  build: conda_forge
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
   purls: []
   size: 2562
   timestamp: 1578324546067
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_gnu
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   build_number: 16
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   md5: 73aaf86a425cc6e73fcf236a5a46396d
   depends:
@@ -1010,13 +1064,8 @@ packages:
   purls: []
   size: 23621
   timestamp: 1650670423406
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_gnu
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
   build_number: 16
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
   sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
   md5: 6168d71addc746e8f2b8d57dfd2edcea
   depends:
@@ -1028,55 +1077,50 @@ packages:
   purls: []
   size: 23712
   timestamp: 1650670790230
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/df/ed/c884465c33c25451e4a5cd4acad154c29e5341e3214e220e7f3478aa4b0d/alembic-1.13.2-py3-none-any.whl
   name: alembic
   version: 1.13.2
-  url: https://files.pythonhosted.org/packages/df/ed/c884465c33c25451e4a5cd4acad154c29e5341e3214e220e7f3478aa4b0d/alembic-1.13.2-py3-none-any.whl
   sha256: 6b8733129a6224a9a711e17c99b08462dbf7cc9670ba8f2e2ae9af860ceb1953
   requires_dist:
   - sqlalchemy>=1.3.0
   - mako
   - typing-extensions>=4
-  - importlib-metadata ; python_version < '3.9'
-  - importlib-resources ; python_version < '3.9'
-  - backports-zoneinfo ; python_version < '3.9' and extra == 'tz'
+  - importlib-metadata ; python_full_version < '3.9'
+  - importlib-resources ; python_full_version < '3.9'
+  - backports-zoneinfo ; python_full_version < '3.9' and extra == 'tz'
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/b3/f0/8e5be5d5e0653d9e1d02b1144efa33ff7d2963dfad07049e02c0fa9b2e8d/amqp-5.2.0-py3-none-any.whl
   name: amqp
   version: 5.2.0
-  url: https://files.pythonhosted.org/packages/b3/f0/8e5be5d5e0653d9e1d02b1144efa33ff7d2963dfad07049e02c0fa9b2e8d/amqp-5.2.0-py3-none-any.whl
   sha256: 827cb12fb0baa892aad844fd95258143bce4027fdac4fccddbc43330fd281637
   requires_dist:
-  - vine<6.0.0,>=5.0.0
+  - vine>=5.0.0,<6.0.0
   requires_python: '>=3.6'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
   name: asttokens
   version: 2.4.1
-  url: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
   sha256: 051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24
   requires_dist:
   - six>=1.12.0
-  - typing ; python_version < '3.5'
-  - astroid<2,>=1 ; python_version < '3' and extra == 'astroid'
-  - astroid<4,>=2 ; python_version >= '3' and extra == 'astroid'
+  - typing ; python_full_version < '3.5'
+  - astroid>=1,<2 ; python_full_version < '3' and extra == 'astroid'
+  - astroid>=2,<4 ; python_full_version >= '3' and extra == 'astroid'
   - pytest ; extra == 'test'
-  - astroid<2,>=1 ; python_version < '3' and extra == 'test'
-  - astroid<4,>=2 ; python_version >= '3' and extra == 'test'
-- kind: pypi
+  - astroid>=1,<2 ; python_full_version < '3' and extra == 'test'
+  - astroid>=2,<4 ; python_full_version >= '3' and extra == 'test'
+- pypi: https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl
   name: async-timeout
   version: 4.0.3
-  url: https://files.pythonhosted.org/packages/a7/fa/e01228c2938de91d47b307831c62ab9e4001e747789d0b05baf779a6488c/async_timeout-4.0.3-py3-none-any.whl
   sha256: 7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028
   requires_dist:
-  - typing-extensions>=3.6.5 ; python_version < '3.8'
+  - typing-extensions>=3.6.5 ; python_full_version < '3.8'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
   name: attrs
   version: 23.2.0
-  url: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
   sha256: 99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
   requires_dist:
-  - importlib-metadata ; python_version < '3.8'
+  - importlib-metadata ; python_full_version < '3.8'
   - attrs[tests] ; extra == 'cov'
   - coverage[toml]>=5.3 ; extra == 'cov'
   - attrs[tests] ; extra == 'dev'
@@ -1090,8 +1134,8 @@ packages:
   - zope-interface ; extra == 'docs'
   - attrs[tests-no-zope] ; extra == 'tests'
   - zope-interface ; extra == 'tests'
-  - mypy>=1.6 ; (platform_python_implementation == 'CPython' and python_version >= '3.8') and extra == 'tests-mypy'
-  - pytest-mypy-plugins ; (platform_python_implementation == 'CPython' and python_version >= '3.8') and extra == 'tests-mypy'
+  - mypy>=1.6 ; python_full_version >= '3.8' and platform_python_implementation == 'CPython' and extra == 'tests-mypy'
+  - pytest-mypy-plugins ; python_full_version >= '3.8' and platform_python_implementation == 'CPython' and extra == 'tests-mypy'
   - attrs[tests-mypy] ; extra == 'tests-no-zope'
   - cloudpickle ; platform_python_implementation == 'CPython' and extra == 'tests-no-zope'
   - hypothesis ; extra == 'tests-no-zope'
@@ -1099,34 +1143,7 @@ packages:
   - pytest-xdist[psutil] ; extra == 'tests-no-zope'
   - pytest>=4.3.0 ; extra == 'tests-no-zope'
   requires_python: '>=3.7'
-- kind: conda
-  name: aws-c-auth
-  version: 0.7.8
-  build: h099566f_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.7.8-h099566f_2.conda
-  sha256: 46597c89e5176da1d298465ae939b746e6174c4a2f56d7598c2913f76cd80bf7
-  md5: efae35d8a5fd543d2ce54cb3ea467651
-  depends:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.7.14,<0.7.15.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 107643
-  timestamp: 1702039704109
-- kind: conda
-  name: aws-c-auth
-  version: 0.7.8
-  build: h538f98c_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.8-h538f98c_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.8-h538f98c_2.conda
   sha256: b06ef95458fc70af4230c9c6690011235cd25288752ff7aa25492fc6d1c0e028
   md5: d42aebb91e28e2fee2a0218cfbff2c90
   depends:
@@ -1141,13 +1158,22 @@ packages:
   purls: []
   size: 102992
   timestamp: 1702039736949
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.9
-  build: h5d48c4d_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.7.8-h099566f_2.conda
+  sha256: 46597c89e5176da1d298465ae939b746e6174c4a2f56d7598c2913f76cd80bf7
+  md5: efae35d8a5fd543d2ce54cb3ea467651
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 107643
+  timestamp: 1702039704109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
   sha256: ec56734a24eee51e2f89bec3d686dd2c4dbb09d0305248b1d14e4c748065dc23
   md5: 9e51dfd5da37c1817d2a850188861987
   depends:
@@ -1159,13 +1185,7 @@ packages:
   purls: []
   size: 55554
   timestamp: 1701212359409
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.9
-  build: h6a88f34_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.6.9-h6a88f34_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.6.9-h6a88f34_2.conda
   sha256: 790c4ec12dfa2ab73a469abf9d7ed137bc4dea520067dbe89c0bb70fbdc7309c
   md5: 1983efb12b3f103966e9b3b57bc9b06f
   depends:
@@ -1177,27 +1197,7 @@ packages:
   purls: []
   size: 48372
   timestamp: 1701212451264
-- kind: conda
-  name: aws-c-common
-  version: 0.9.10
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.9.10-h31becfc_0.conda
-  sha256: 9f79f82d7d942b25d42d72676b5a504a9567d624b8cf7ec45102f293358fa4b9
-  md5: bf24e70a2b2c2bac4d0e35088a487259
-  depends:
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 232115
-  timestamp: 1701169732571
-- kind: conda
-  name: aws-c-common
-  version: 0.9.10
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
   sha256: dba8a20acedc6bc3574e4068c196969881462ad831aae267d25fbc9409785a6b
   md5: 93729f7a54b25cb135ac2b67ea3a7603
   depends:
@@ -1207,13 +1207,17 @@ packages:
   purls: []
   size: 225475
   timestamp: 1701169650086
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.17
-  build: h7f92143_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.9.10-h31becfc_0.conda
+  sha256: 9f79f82d7d942b25d42d72676b5a504a9567d624b8cf7ec45102f293358fa4b9
+  md5: bf24e70a2b2c2bac4d0e35088a487259
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 232115
+  timestamp: 1701169732571
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
   sha256: ce508018c1109d4e5c6b65695639deaa2beea31edc39145bb810efb13ffed2c3
   md5: c55a1a0c1419fcdfce6d21c41b0f92ab
   depends:
@@ -1224,13 +1228,7 @@ packages:
   purls: []
   size: 19185
   timestamp: 1701212362896
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.17
-  build: hb4825c3_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.2.17-hb4825c3_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.2.17-hb4825c3_7.conda
   sha256: 1f5e63559df3b62fdcc2bdf7790303defc23c2cc4a08eb2882dc0423df14f9d5
   md5: b9f7771957697dadf265ef5871cd72f6
   depends:
@@ -1241,33 +1239,7 @@ packages:
   purls: []
   size: 19908
   timestamp: 1701212387878
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.3.2
-  build: h028cdfe_8
-  build_number: 8
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-event-stream-0.3.2-h028cdfe_8.conda
-  sha256: 3dc8e1b14dcecedc71a4d84e21d89587e18098bd0543450d9f8ecac5cddee727
-  md5: d0c9f0409784ec5a3c475f28a0c7787a
-  depends:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 55364
-  timestamp: 1701263269510
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.3.2
-  build: h0bcb0bb_8
-  build_number: 8
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-h0bcb0bb_8.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-h0bcb0bb_8.conda
   sha256: d2855cd791a95648ac773aa6561c61f9e77450f123c8aa82eea1d66e90d5bfb1
   md5: 21dafb60b5854f82b196f32e5857dec6
   depends:
@@ -1281,33 +1253,21 @@ packages:
   purls: []
   size: 54136
   timestamp: 1701263274039
-- kind: conda
-  name: aws-c-http
-  version: 0.7.14
-  build: h0a9a19f_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.7.14-h0a9a19f_3.conda
-  sha256: 33a06f12de64ccc604472c8a3f939b26bf73b483ba7c27da712cbd7cd4122137
-  md5: 5d5cad062d363145417996813ceb5e03
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-event-stream-0.3.2-h028cdfe_8.conda
+  sha256: 3dc8e1b14dcecedc71a4d84e21d89587e18098bd0543450d9f8ecac5cddee727
+  md5: d0c9f0409784ec5a3c475f28a0c7787a
   depends:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-compression >=0.2.17,<0.2.18.0a0
   - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
   - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 187672
-  timestamp: 1701248647459
-- kind: conda
-  name: aws-c-http
-  version: 0.7.14
-  build: hd268abd_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-hd268abd_3.conda
+  size: 55364
+  timestamp: 1701263269510
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-hd268abd_3.conda
   sha256: ff7e6252a299a59b7e6494723ef3043ba31643ec2a750b8593037bc757a2c4fa
   md5: 0b0f7174a0f94d2c9a02fb24f6fc0d00
   depends:
@@ -1321,32 +1281,21 @@ packages:
   purls: []
   size: 194249
   timestamp: 1701248521692
-- kind: conda
-  name: aws-c-io
-  version: 0.13.36
-  build: hcd54cbc_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.13.36-hcd54cbc_2.conda
-  sha256: cfa36b413f86bf815613507ed6db779d44198a8cf7abbcd1d67a3f44aef88675
-  md5: 85b6057b66ada2d0242a01529f960493
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.7.14-h0a9a19f_3.conda
+  sha256: 33a06f12de64ccc604472c8a3f939b26bf73b483ba7c27da712cbd7cd4122137
+  md5: 5d5cad062d363145417996813ceb5e03
   depends:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
   - libgcc-ng >=12
-  - s2n >=1.4.0,<1.4.1.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 159957
-  timestamp: 1702039111938
-- kind: conda
-  name: aws-c-io
-  version: 0.13.36
-  build: he0cd244_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-he0cd244_2.conda
+  size: 187672
+  timestamp: 1701248647459
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-he0cd244_2.conda
   sha256: 7426f7444cd43cd7a649670c7330c163b40f40aa832e82be873d9de91e49b05e
   md5: c930336aa72995f1b5459b51df3ba841
   depends:
@@ -1359,13 +1308,20 @@ packages:
   purls: []
   size: 156952
   timestamp: 1702039096578
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.9.10
-  build: h35285c7_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.10-h35285c7_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.13.36-hcd54cbc_2.conda
+  sha256: cfa36b413f86bf815613507ed6db779d44198a8cf7abbcd1d67a3f44aef88675
+  md5: 85b6057b66ada2d0242a01529f960493
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  - s2n >=1.4.0,<1.4.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 159957
+  timestamp: 1702039111938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.10-h35285c7_2.conda
   sha256: 246276b22393302b4e9acb934ec40bb78d3be74e7bd2c110272b46c5370a60ee
   md5: 0cca0a3d7dc82f219ac46635478952f6
   depends:
@@ -1378,13 +1334,7 @@ packages:
   purls: []
   size: 164618
   timestamp: 1701264087679
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.9.10
-  build: hd720f31_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-mqtt-0.9.10-hd720f31_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-mqtt-0.9.10-hd720f31_2.conda
   sha256: 60efe4e049c20364d967afa50ce2213e96b96f7892c37dd7b0cca9dbc8caf812
   md5: b8a3e756c867120f24ca8308ce9c4bd0
   depends:
@@ -1397,12 +1347,7 @@ packages:
   purls: []
   size: 146612
   timestamp: 1701263736177
-- kind: conda
-  name: aws-c-s3
-  version: 0.4.4
-  build: h0448019_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.4-h0448019_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.4-h0448019_0.conda
   sha256: 04142edf1a574e137a9e30a4f4e9b9448e219b6f4216a782ceaed933f27852a6
   md5: f27f792aa83c7be3ee96d09a637a6474
   depends:
@@ -1419,12 +1364,7 @@ packages:
   purls: []
   size: 103004
   timestamp: 1702065571082
-- kind: conda
-  name: aws-c-s3
-  version: 0.4.4
-  build: h937fcef_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.4.4-h937fcef_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.4.4-h937fcef_0.conda
   sha256: 13aa37db302921fdd2c2c710565d0c51285771f13c09c4f8c57f4404ca80ccd8
   md5: 709fc2da7cec72eb3d3ccad1785dd73d
   depends:
@@ -1441,12 +1381,7 @@ packages:
   purls: []
   size: 107672
   timestamp: 1702065600078
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.13
-  build: h7f92143_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h7f92143_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h7f92143_0.conda
   sha256: 8696e7023fde7c4588db8aedd08ffc0b4041c8449bd9edd50f237534cbcfac93
   md5: a4a83424ad4eab023c6e5b4adf264006
   depends:
@@ -1457,12 +1392,7 @@ packages:
   purls: []
   size: 53339
   timestamp: 1701999463183
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.13
-  build: hb4825c3_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.1.13-hb4825c3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.1.13-hb4825c3_0.conda
   sha256: 4ea06792464b0971ceca48f5cdc16d87a76080fcd1e056d7ee2d873fb3feb84e
   md5: 41d238e1fae2eccd206d977be845649b
   depends:
@@ -1473,13 +1403,7 @@ packages:
   purls: []
   size: 55071
   timestamp: 1701999496951
-- kind: conda
-  name: aws-checksums
-  version: 0.1.17
-  build: h7f92143_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
   sha256: ac2082211e7d5fd3036f9abd7e398ef67d5327efb3808f17a30fcab59acacbfb
   md5: 46bd4e9c2fd10de83bae22f0bb71139b
   depends:
@@ -1490,13 +1414,7 @@ packages:
   purls: []
   size: 50162
   timestamp: 1701246709430
-- kind: conda
-  name: aws-checksums
-  version: 0.1.17
-  build: hb4825c3_6
-  build_number: 6
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.1.17-hb4825c3_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.1.17-hb4825c3_6.conda
   sha256: 6ae4b9b8009f6e12e2c7f4ddb11097692fc543f03a2257158e9eece976d65833
   md5: 87890bbef540f39f9bf3e1fac630f877
   depends:
@@ -1507,12 +1425,31 @@ packages:
   purls: []
   size: 50009
   timestamp: 1701246717008
-- kind: conda
-  name: awscli
-  version: 2.15.24
-  build: py310h4c7bcd0_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.15.24-py310h4c7bcd0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.15.24-py310hff52083_0.conda
+  sha256: 530de64adafa60944dbba27f9535e618452373fe03e9112ef7a884325c0154ba
+  md5: 177728a95f2c5f4083f749174d4f2b8b
+  depends:
+  - awscrt >=0.19.18,<=0.19.19
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=3.3.2,<=40.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - pyopenssl <23.2
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.1,<3.0.0
+  - python_abi 3.10.* *_cp310
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.7
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/awscli?source=conda-forge-mapping
+  size: 11590519
+  timestamp: 1709162931952
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.15.24-py310h4c7bcd0_0.conda
   sha256: a27d5a13451e4c954758449a2fb44bb170081911dfc85bd9cd82b518a8fd80be
   md5: 22f92450cb44fb6f7a1b0fc2dff88719
   depends:
@@ -1537,42 +1474,7 @@ packages:
   - pkg:pypi/awscli?source=conda-forge-mapping
   size: 11639919
   timestamp: 1709163023737
-- kind: conda
-  name: awscli
-  version: 2.15.24
-  build: py310hff52083_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.15.24-py310hff52083_0.conda
-  sha256: 530de64adafa60944dbba27f9535e618452373fe03e9112ef7a884325c0154ba
-  md5: 177728a95f2c5f4083f749174d4f2b8b
-  depends:
-  - awscrt >=0.19.18,<=0.19.19
-  - colorama >=0.2.5,<0.4.7
-  - cryptography >=3.3.2,<=40.0.2
-  - distro >=1.5.0,<1.9.0
-  - docutils >=0.10,<0.20
-  - jmespath >=0.7.1,<1.1.0
-  - prompt_toolkit >=3.0.24,<3.0.39
-  - pyopenssl <23.2
-  - python >=3.10,<3.11.0a0
-  - python-dateutil >=2.1,<3.0.0
-  - python_abi 3.10.* *_cp310
-  - ruamel.yaml >=0.15.0,<=0.17.21
-  - ruamel.yaml.clib >=0.2.0,<=0.2.7
-  - urllib3 >=1.25.4,<1.27
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/awscli?source=conda-forge-mapping
-  size: 11590519
-  timestamp: 1709162931952
-- kind: conda
-  name: awscrt
-  version: 0.19.19
-  build: py310h43b4219_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.19.19-py310h43b4219_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.19.19-py310h43b4219_2.conda
   sha256: bdab178420ff1e1dcf13407c662d355290bbad434844ed903029f98cd8afc29c
   md5: fd4b703083170315b3735e43967e3983
   depends:
@@ -1595,13 +1497,7 @@ packages:
   - pkg:pypi/awscrt?source=conda-forge-mapping
   size: 172142
   timestamp: 1702083003791
-- kind: conda
-  name: awscrt
-  version: 0.19.19
-  build: py310h7d5d209_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/awscrt-0.19.19-py310h7d5d209_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscrt-0.19.19-py310h7d5d209_2.conda
   sha256: 967af45fbe75e45c672c312a121b114de1be0d7ec2756a65d1f768317ed70d31
   md5: 22fcbfdeda16af30310e69bbc817ae7e
   depends:
@@ -1625,35 +1521,26 @@ packages:
   - pkg:pypi/awscrt?source=conda-forge-mapping
   size: 176487
   timestamp: 1702083061770
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/50/8d/6e9fdeeab04d803abc5a715175f87e88893934d5590595eacff23ca12b07/billiard-4.2.0-py3-none-any.whl
   name: billiard
   version: 4.2.0
-  url: https://files.pythonhosted.org/packages/50/8d/6e9fdeeab04d803abc5a715175f87e88893934d5590595eacff23ca12b07/billiard-4.2.0-py3-none-any.whl
   sha256: 07aa978b308f334ff8282bd4a746e681b3513db5c9a514cbdd810cbbdc19714d
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/46/3a/ebabbce6d7356091152402543ba2e3b2270cd12dd8153d800e585fa88900/biopython-1.84-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: biopython
   version: '1.84'
-  url: https://files.pythonhosted.org/packages/46/3a/ebabbce6d7356091152402543ba2e3b2270cd12dd8153d800e585fa88900/biopython-1.84-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 2dc2e77490725060330003f73b6b7d5172f8bc160f180de5877a2e899ad999d4
   requires_dist:
   - numpy
   requires_python: '>=3.9'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/57/fd/99f06b60fd7a5de22b9f3ca279a25def5ce16a629025e453fbf53e4ec6d4/biopython-1.84-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: biopython
   version: '1.84'
-  url: https://files.pythonhosted.org/packages/57/fd/99f06b60fd7a5de22b9f3ca279a25def5ce16a629025e453fbf53e4ec6d4/biopython-1.84-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: ca8d6a88b9a9718074b3f5b450f9ea5adf7112a7dbaed55d82d5b623f5859a01
   requires_dist:
   - numpy
   requires_python: '>=3.9'
-- kind: conda
-  name: bitstring
-  version: 3.1.9
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/bitstring-3.1.9-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/bitstring-3.1.9-pyhd8ed1ab_0.tar.bz2
   sha256: 14b3b51d20047c5d264da3280f1e686164f3af646661c8db0a4f6decb6709de7
   md5: 94a9bc42263c78cd2ee8868d0b5986a0
   depends:
@@ -1664,60 +1551,32 @@ packages:
   - pkg:pypi/bitstring?source=conda-forge-mapping
   size: 34679
   timestamp: 1626809967321
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/bb/2a/10164ed1f31196a2f7f3799368a821765c62851ead0e630ab52b8e14b4d0/blinker-1.8.2-py3-none-any.whl
   name: blinker
   version: 1.8.2
-  url: https://files.pythonhosted.org/packages/bb/2a/10164ed1f31196a2f7f3799368a821765c62851ead0e630ab52b8e14b4d0/blinker-1.8.2-py3-none-any.whl
   sha256: 1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/62/fa/04e99eb81c703e0ef6c8e503fc7d74c8d836157ed15d61bc77f4fd1c6e73/boto3-1.26.165-py3-none-any.whl
   name: boto3
   version: 1.26.165
-  url: https://files.pythonhosted.org/packages/62/fa/04e99eb81c703e0ef6c8e503fc7d74c8d836157ed15d61bc77f4fd1c6e73/boto3-1.26.165-py3-none-any.whl
   sha256: fa85b67147c8dc99b6e7c699fc086103f958f9677db934f70659e6e6a72a818c
   requires_dist:
-  - botocore<1.30.0,>=1.29.165
-  - jmespath<2.0.0,>=0.7.1
-  - s3transfer<0.7.0,>=0.6.0
-  - botocore[crt]<2.0a0,>=1.21.0 ; extra == 'crt'
+  - botocore>=1.29.165,<1.30.0
+  - jmespath>=0.7.1,<2.0.0
+  - s3transfer>=0.6.0,<0.7.0
+  - botocore[crt]>=1.21.0,<2.0a0 ; extra == 'crt'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/46/20/e7a9a8e6746872afcc4e3ad5ab503702c38813b3a532df27cce95c98b8cb/botocore-1.29.165-py3-none-any.whl
   name: botocore
   version: 1.29.165
-  url: https://files.pythonhosted.org/packages/46/20/e7a9a8e6746872afcc4e3ad5ab503702c38813b3a532df27cce95c98b8cb/botocore-1.29.165-py3-none-any.whl
   sha256: 6f35d59e230095aed7cd747604fe248fa384bebb7d09549077892f936a8ca3df
   requires_dist:
-  - jmespath<2.0.0,>=0.7.1
-  - python-dateutil<3.0.0,>=2.1
-  - urllib3<1.27,>=1.25.4
+  - jmespath>=0.7.1,<2.0.0
+  - python-dateutil>=2.1,<3.0.0
+  - urllib3>=1.25.4,<1.27
   - awscrt==0.16.9 ; extra == 'crt'
   requires_python: '>=3.7'
-- kind: conda
-  name: brotli
-  version: 1.1.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.1.0-h31becfc_1.conda
-  sha256: 1e1e46a4d16936d1bd1a605767b4cc36cf8fd3180ad776b5ba9e4c8ce64859bf
-  md5: e41f5862ac746428407f3fd44d2ed01f
-  depends:
-  - brotli-bin 1.1.0 h31becfc_1
-  - libbrotlidec 1.1.0 h31becfc_1
-  - libbrotlienc 1.1.0 h31becfc_1
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 19586
-  timestamp: 1695990171649
-- kind: conda
-  name: brotli
-  version: 1.1.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
   sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
   md5: f27a24d46e3ea7b70a1f98e50c62508f
   depends:
@@ -1730,31 +1589,20 @@ packages:
   purls: []
   size: 19383
   timestamp: 1695990069230
-- kind: conda
-  name: brotli-bin
-  version: 1.1.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.1.0-h31becfc_1.conda
-  sha256: fd1e57615b995565939fdb9910534933c4c27ec0c37a911a2c923241dbf8ad3b
-  md5: 9e4a13596ab651ea8d77aae023d0ce3f
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.1.0-h31becfc_1.conda
+  sha256: 1e1e46a4d16936d1bd1a605767b4cc36cf8fd3180ad776b5ba9e4c8ce64859bf
+  md5: e41f5862ac746428407f3fd44d2ed01f
   depends:
+  - brotli-bin 1.1.0 h31becfc_1
   - libbrotlidec 1.1.0 h31becfc_1
   - libbrotlienc 1.1.0 h31becfc_1
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 18915
-  timestamp: 1695990154825
-- kind: conda
-  name: brotli-bin
-  version: 1.1.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
+  size: 19586
+  timestamp: 1695990171649
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
   sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
   md5: 39f910d205726805a958da408ca194ba
   depends:
@@ -1766,13 +1614,35 @@ packages:
   purls: []
   size: 18980
   timestamp: 1695990054140
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py310hbb3657e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-python-1.1.0-py310hbb3657e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.1.0-h31becfc_1.conda
+  sha256: fd1e57615b995565939fdb9910534933c4c27ec0c37a911a2c923241dbf8ad3b
+  md5: 9e4a13596ab651ea8d77aae023d0ce3f
+  depends:
+  - libbrotlidec 1.1.0 h31becfc_1
+  - libbrotlienc 1.1.0 h31becfc_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 18915
+  timestamp: 1695990154825
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+  sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
+  md5: 1f95722c94f00b69af69a066c7433714
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.1.0 hd590300_1
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=conda-forge-mapping
+  size: 349397
+  timestamp: 1695990295884
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-python-1.1.0-py310hbb3657e_1.conda
   sha256: 192f2537ca30953653375abd851f1ccf8b849988e3195e0189aa47384a3a88d9
   md5: 5ed52d1d3c480022fe67ae00d1cab792
   depends:
@@ -1789,35 +1659,7 @@ packages:
   - pkg:pypi/brotli?source=conda-forge-mapping
   size: 355646
   timestamp: 1695990521531
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py310hc6cd4ac_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
-  sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
-  md5: 1f95722c94f00b69af69a066c7433714
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - libbrotlicommon 1.1.0 hd590300_1
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/brotli?source=conda-forge-mapping
-  size: 349397
-  timestamp: 1695990295884
-- kind: conda
-  name: build
-  version: 0.7.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
   sha256: 44e2d3270209d1f10b8adec2a159699ed66914e851ec34775902e856ea04afeb
   md5: add7f31586d03678695b32b78a1337a1
   depends:
@@ -1832,13 +1674,7 @@ packages:
   - pkg:pypi/build?source=conda-forge-mapping
   size: 17759
   timestamp: 1631843776429
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h4bc722e_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
   sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
   md5: 62ee74e96c5ebb0af99386de58cf9553
   depends:
@@ -1849,13 +1685,7 @@ packages:
   purls: []
   size: 252783
   timestamp: 1720974456583
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h68df207_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
   sha256: 2258b0b33e1cb3a9852d47557984abb6e7ea58e3d7f92706ec1f8e879290c4cb
   md5: 56398c28220513b9ea13d7b450acfb20
   depends:
@@ -1865,12 +1695,7 @@ packages:
   purls: []
   size: 189884
   timestamp: 1720974504976
-- kind: conda
-  name: c-ares
-  version: 1.32.3
-  build: h4bc722e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
   sha256: 3c5a844bb60b0d52d89c3f1bd828c9856417fe33a6102fd8bbd5c13c3351704a
   md5: 7624e34ee6baebfc80d67bac76cc9d9d
   depends:
@@ -1881,12 +1706,7 @@ packages:
   purls: []
   size: 179736
   timestamp: 1721834714515
-- kind: conda
-  name: c-ares
-  version: 1.32.3
-  build: h68df207_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.32.3-h68df207_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.32.3-h68df207_0.conda
   sha256: 9c0505e6e8a23c85f10e4b5c8924c4f9d51cccb89b81b59369b167adf2448fd1
   md5: 13d442f0a28e5a71073328a9b2140cb8
   depends:
@@ -1896,37 +1716,21 @@ packages:
   purls: []
   size: 187241
   timestamp: 1721834713576
-- kind: conda
-  name: ca-certificates
-  version: 2024.7.4
-  build: hbcca054_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
   sha256: c1548a3235376f464f9931850b64b02492f379b2f2bb98bc786055329b080446
   md5: 23ab7665c5f63cfb9f1f6195256daac6
   license: ISC
   purls: []
   size: 154853
   timestamp: 1720077432978
-- kind: conda
-  name: ca-certificates
-  version: 2024.7.4
-  build: hcefe29a_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.7.4-hcefe29a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.7.4-hcefe29a_0.conda
   sha256: 562bfc2608d82996a08e5b5b2366ed319a51ace6a2518a004ba672edca75fc23
   md5: c4c784a1336d72fff54f6b207f3dd75f
   license: ISC
   purls: []
   size: 154904
   timestamp: 1720078197019
-- kind: conda
-  name: cachelib
-  version: 0.10.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cachelib-0.10.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cachelib-0.10.2-pyhd8ed1ab_0.conda
   sha256: b16633b44c7603152d8d6c4c62087297d4aa6ce0cccbc8749a3150604f17e300
   md5: ed18995d5c0734bd3b2744750921714b
   depends:
@@ -1937,13 +1741,7 @@ packages:
   - pkg:pypi/cachelib?source=conda-forge-mapping
   size: 20115
   timestamp: 1675325832433
-- kind: conda
-  name: cachetools
-  version: 4.2.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-4.2.4-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-4.2.4-pyhd8ed1ab_0.tar.bz2
   sha256: c73709b168d12c802532706961dc8e54418b61cf99341fd6738bae060460c477
   md5: 059a8732c1d81ffc93997cb8a236331f
   depends:
@@ -1954,68 +1752,61 @@ packages:
   - pkg:pypi/cachetools?source=conda-forge-mapping
   size: 12742
   timestamp: 1633011054959
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/37/c2/4c8a67a4d98a6fcd55dbdd79b641f945d7f59637c3e885c4abbda3c431f6/celery-5.3.6-py3-none-any.whl
   name: celery
   version: 5.3.6
-  url: https://files.pythonhosted.org/packages/37/c2/4c8a67a4d98a6fcd55dbdd79b641f945d7f59637c3e885c4abbda3c431f6/celery-5.3.6-py3-none-any.whl
   sha256: 9da4ea0118d232ce97dff5ed4974587fb1c0ff5c10042eb15278487cdd27d1af
   requires_dist:
-  - billiard<5.0,>=4.2.0
+  - billiard>=4.2.0,<5.0
   - click-didyoumean>=0.3.0
   - click-plugins>=1.1.1
   - click-repl>=0.2.0
-  - click<9.0,>=8.1.2
-  - kombu<6.0,>=5.3.4
+  - click>=8.1.2,<9.0
+  - kombu>=5.3.4,<6.0
   - python-dateutil>=2.8.2
   - tzdata>=2022.7
-  - vine<6.0,>=5.1.0
-  - importlib-metadata>=3.6 ; python_version < '3.8'
-  - backports-zoneinfo>=0.2.1 ; python_version < '3.9'
+  - vine>=5.1.0,<6.0
+  - importlib-metadata>=3.6 ; python_full_version < '3.8'
+  - backports-zoneinfo>=0.2.1 ; python_full_version < '3.9'
   - pyarango>=2.0.2 ; extra == 'arangodb'
   - cryptography==41.0.5 ; extra == 'auth'
   - azure-storage-blob>=12.15.0 ; extra == 'azureblockblob'
   - brotli>=1.0.0 ; platform_python_implementation == 'CPython' and extra == 'brotli'
   - brotlipy>=0.7.0 ; platform_python_implementation == 'PyPy' and extra == 'brotli'
-  - cassandra-driver<4,>=3.25.0 ; extra == 'cassandra'
+  - cassandra-driver>=3.25.0,<4 ; extra == 'cassandra'
   - python-consul2==0.1.5 ; extra == 'consul'
   - pydocumentdb==2.3.5 ; extra == 'cosmosdbsql'
-  - couchbase>=3.0.0 ; (platform_python_implementation != 'PyPy' and (platform_system != 'Windows' or python_version < '3.10')) and extra == 'couchbase'
+  - couchbase>=3.0.0 ; (python_full_version < '3.10' and platform_python_implementation != 'PyPy' and extra == 'couchbase') or (platform_python_implementation != 'PyPy' and platform_system != 'Windows' and extra == 'couchbase')
   - pycouchdb==1.14.2 ; extra == 'couchdb'
   - django>=2.2.28 ; extra == 'django'
   - boto3>=1.26.143 ; extra == 'dynamodb'
   - elastic-transport<=8.10.0 ; extra == 'elasticsearch'
   - elasticsearch<=8.11.0 ; extra == 'elasticsearch'
-  - eventlet>=0.32.0 ; python_version < '3.10' and extra == 'eventlet'
+  - eventlet>=0.32.0 ; python_full_version < '3.10' and extra == 'eventlet'
   - gevent>=1.5.0 ; extra == 'gevent'
-  - librabbitmq>=2.0.0 ; python_version < '3.11' and extra == 'librabbitmq'
+  - librabbitmq>=2.0.0 ; python_full_version < '3.11' and extra == 'librabbitmq'
   - pylibmc==1.6.3 ; platform_system != 'Windows' and extra == 'memcache'
   - pymongo[srv]>=4.0.2 ; extra == 'mongodb'
   - msgpack==1.0.7 ; extra == 'msgpack'
   - python-memcached==1.59 ; extra == 'pymemcache'
-  - pyro4==4.82 ; python_version < '3.11' and extra == 'pyro'
+  - pyro4==4.82 ; python_full_version < '3.11' and extra == 'pyro'
   - pytest-celery==0.0.0 ; extra == 'pytest'
-  - redis!=4.5.5,<6.0.0,>=4.5.2 ; extra == 'redis'
+  - redis>=4.5.2,!=4.5.5,<6.0.0 ; extra == 'redis'
   - boto3>=1.26.143 ; extra == 's3'
   - softlayer-messaging>=1.0.3 ; extra == 'slmq'
   - ephem==4.1.5 ; platform_python_implementation != 'PyPy' and extra == 'solar'
-  - sqlalchemy<2.1,>=1.4.48 ; extra == 'sqlalchemy'
+  - sqlalchemy>=1.4.48,<2.1 ; extra == 'sqlalchemy'
   - boto3>=1.26.143 ; extra == 'sqs'
   - kombu[sqs]>=5.3.0 ; extra == 'sqs'
   - urllib3>=1.26.16 ; extra == 'sqs'
-  - pycurl>=7.43.0.5 ; (sys_platform != 'win32' and platform_python_implementation == 'CPython') and extra == 'sqs'
-  - tblib>=1.3.0 ; python_version < '3.8.0' and extra == 'tblib'
-  - tblib>=1.5.0 ; python_version >= '3.8.0' and extra == 'tblib'
+  - pycurl>=7.43.0.5 ; platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'sqs'
+  - tblib>=1.3.0 ; python_full_version < '3.8' and extra == 'tblib'
+  - tblib>=1.5.0 ; python_full_version >= '3.8' and extra == 'tblib'
   - pyyaml>=3.10 ; extra == 'yaml'
   - kazoo>=1.3.1 ; extra == 'zookeeper'
   - zstandard==0.22.0 ; extra == 'zstd'
   requires_python: '>=3.8'
-- kind: conda
-  name: certifi
-  version: 2024.7.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
   sha256: dd3577bb5275062c388c46b075dcb795f47f8dac561da7dd35fe504b936934e5
   md5: 24e7fd6ca65997938fff9e5ab6f653e4
   depends:
@@ -2025,12 +1816,7 @@ packages:
   - pkg:pypi/certifi?source=conda-forge-mapping
   size: 159308
   timestamp: 1720458053074
-- kind: conda
-  name: cffi
-  version: 1.16.0
-  build: py310h2fee648_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
   sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
   md5: 45846a970e71ac98fd327da5d40a0a2c
   depends:
@@ -2045,12 +1831,7 @@ packages:
   - pkg:pypi/cffi?source=conda-forge-mapping
   size: 241339
   timestamp: 1696001848492
-- kind: conda
-  name: cffi
-  version: 1.16.0
-  build: py310hce94938_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.16.0-py310hce94938_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.16.0-py310hce94938_0.conda
   sha256: 99d1333522c85fc4342988a4b070ab672ba248d4ebb7a9de42fbcee9d21980fe
   md5: 69f5188c0b23d70d99e1f4153fe498cd
   depends:
@@ -2065,39 +1846,34 @@ packages:
   - pkg:pypi/cffi?source=conda-forge-mapping
   size: 260773
   timestamp: 1696003162331
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/b8/60/e2f67915a51be59d4539ed189eb0a2b0d292bf79270410746becb32bc2c3/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: charset-normalizer
   version: 3.3.2
-  url: https://files.pythonhosted.org/packages/b8/60/e2f67915a51be59d4539ed189eb0a2b0d292bf79270410746becb32bc2c3/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: 6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d
   requires_python: '>=3.7.0'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/da/f1/3702ba2a7470666a62fd81c58a4c40be00670e5006a67f4d626e57f013ae/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: charset-normalizer
   version: 3.3.2
-  url: https://files.pythonhosted.org/packages/da/f1/3702ba2a7470666a62fd81c58a4c40be00670e5006a67f4d626e57f013ae/charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5
   requires_python: '>=3.7.0'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
   name: click
   version: 8.1.7
-  url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
   sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
   requires_dist:
   - colorama ; platform_system == 'Windows'
-  - importlib-metadata ; python_version < '3.8'
+  - importlib-metadata ; python_full_version < '3.8'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl
   name: click-didyoumean
   version: 0.3.1
-  url: https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl
   sha256: 5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c
   requires_dist:
   - click>=7
   requires_python: '>=3.6.2'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/e9/da/824b92d9942f4e472702488857914bdd50f73021efea15b4cad9aca8ecef/click_plugins-1.1.1-py2.py3-none-any.whl
   name: click-plugins
   version: 1.1.1
-  url: https://files.pythonhosted.org/packages/e9/da/824b92d9942f4e472702488857914bdd50f73021efea15b4cad9aca8ecef/click_plugins-1.1.1-py2.py3-none-any.whl
   sha256: 5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8
   requires_dist:
   - click>=4.0
@@ -2105,10 +1881,9 @@ packages:
   - pytest-cov ; extra == 'dev'
   - wheel ; extra == 'dev'
   - coveralls ; extra == 'dev'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl
   name: click-repl
   version: 0.3.0
-  url: https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl
   sha256: fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812
   requires_dist:
   - click>=7.0
@@ -2117,21 +1892,14 @@ packages:
   - pytest>=7.2.1 ; extra == 'testing'
   - tox>=4.4.3 ; extra == 'testing'
   requires_python: '>=3.6'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl
   name: clickclick
   version: 20.10.2
-  url: https://files.pythonhosted.org/packages/7a/7e/c08007d3fb2bbefb430437a3573373590abedc03566b785d7d6763b22480/clickclick-20.10.2-py2.py3-none-any.whl
   sha256: c8f33e6d9ec83f68416dd2136a7950125bd256ec39ccc9a85c6e280a16be2bb5
   requires_dist:
   - pyyaml>=3.11
   - click>=4.0
-- kind: conda
-  name: colorama
-  version: 0.4.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   md5: 3faab06a954c2a04039983f2c4a50d99
   depends:
@@ -2142,48 +1910,57 @@ packages:
   - pkg:pypi/colorama?source=conda-forge-mapping
   size: 25170
   timestamp: 1666700778190
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/ed/e6/851b3d7688115b176eb5d3e45055d1dc5b2b91708007064a38b0e93813ed/connexion-2.14.2-py2.py3-none-any.whl
   name: connexion
   version: 2.14.2
-  url: https://files.pythonhosted.org/packages/ed/e6/851b3d7688115b176eb5d3e45055d1dc5b2b91708007064a38b0e93813ed/connexion-2.14.2-py2.py3-none-any.whl
   sha256: a73b96a0e07b16979a42cde7c7e26afe8548099e352cf350f80c57185e0e0b36
   requires_dist:
-  - clickclick<21,>=1.2
-  - jsonschema<5,>=2.5.1
-  - pyyaml<7,>=5.1
-  - requests<3,>=2.9.1
-  - inflection<0.6,>=0.3.1
-  - werkzeug<2.3,>=1.0
+  - clickclick>=1.2,<21
+  - jsonschema>=2.5.1,<5
+  - pyyaml>=5.1,<7
+  - requests>=2.9.1,<3
+  - inflection>=0.3.1,<0.6
+  - werkzeug>=1.0,<2.3
   - packaging>=20
-  - flask<2.3,>=1.0.4
+  - flask>=1.0.4,<2.3
   - itsdangerous>=0.24
-  - importlib-metadata>=1 ; python_version < '3.8'
-  - aiohttp<4,>=2.3.10 ; extra == 'aiohttp'
-  - aiohttp-jinja2<2,>=0.14.0 ; extra == 'aiohttp'
+  - importlib-metadata>=1 ; python_full_version < '3.8'
+  - aiohttp>=2.3.10,<4 ; extra == 'aiohttp'
+  - aiohttp-jinja2>=0.14.0,<2 ; extra == 'aiohttp'
   - markupsafe>=0.23 ; extra == 'aiohttp'
   - sphinx-autoapi==1.8.1 ; extra == 'docs'
-  - flask<2.3,>=1.0.4 ; extra == 'flask'
+  - flask>=1.0.4,<2.3 ; extra == 'flask'
   - itsdangerous>=0.24 ; extra == 'flask'
-  - swagger-ui-bundle<0.1,>=0.0.2 ; extra == 'swagger-ui'
-  - decorator<6,>=5 ; extra == 'tests'
-  - pytest<7,>=6 ; extra == 'tests'
-  - pytest-cov<3,>=2 ; extra == 'tests'
-  - testfixtures<7,>=6 ; extra == 'tests'
-  - flask<2.3,>=1.0.4 ; extra == 'tests'
+  - swagger-ui-bundle>=0.0.2,<0.1 ; extra == 'swagger-ui'
+  - decorator>=5,<6 ; extra == 'tests'
+  - pytest>=6,<7 ; extra == 'tests'
+  - pytest-cov>=2,<3 ; extra == 'tests'
+  - testfixtures>=6,<7 ; extra == 'tests'
+  - flask>=1.0.4,<2.3 ; extra == 'tests'
   - itsdangerous>=0.24 ; extra == 'tests'
-  - swagger-ui-bundle<0.1,>=0.0.2 ; extra == 'tests'
-  - aiohttp<4,>=2.3.10 ; extra == 'tests'
-  - aiohttp-jinja2<2,>=0.14.0 ; extra == 'tests'
+  - swagger-ui-bundle>=0.0.2,<0.1 ; extra == 'tests'
+  - aiohttp>=2.3.10,<4 ; extra == 'tests'
+  - aiohttp-jinja2>=0.14.0,<2 ; extra == 'tests'
   - markupsafe>=0.23 ; extra == 'tests'
   - pytest-aiohttp ; extra == 'tests'
   - aiohttp-remotes ; extra == 'tests'
   requires_python: '>=3.6'
-- kind: conda
-  name: contourpy
-  version: 1.2.1
-  build: py310h586407a_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.2.1-py310h586407a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py310hd41b1e2_0.conda
+  sha256: b9283a52ec79bf71325cde80b8845e86bdf9ac80d8b38f95ad47cbaab32447fe
+  md5: 60ee50b1968f802f2a487ba36d4cce0d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.20
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/contourpy?source=conda-forge-mapping
+  size: 241947
+  timestamp: 1712430089559
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.2.1-py310h586407a_0.conda
   sha256: 656c5f1415495224d4dcf5f5baad4ca73879c35bb16c433b6bdabd48778ce10f
   md5: 2104865045566cb04092d93959960bba
   depends:
@@ -2199,51 +1976,7 @@ packages:
   - pkg:pypi/contourpy?source=conda-forge-mapping
   size: 247870
   timestamp: 1712430256989
-- kind: conda
-  name: contourpy
-  version: 1.2.1
-  build: py310hd41b1e2_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py310hd41b1e2_0.conda
-  sha256: b9283a52ec79bf71325cde80b8845e86bdf9ac80d8b38f95ad47cbaab32447fe
-  md5: 60ee50b1968f802f2a487ba36d4cce0d
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.20
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/contourpy?source=conda-forge-mapping
-  size: 241947
-  timestamp: 1712430089559
-- kind: conda
-  name: coverage
-  version: 7.6.0
-  build: py310h03727f4_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.6.0-py310h03727f4_0.conda
-  sha256: fce08e6b23aaa71b811abdda8c167c297e2adf26e9d4462372521daf4fe31246
-  md5: 3db345fdb61ed845c4dd25c50edf5d94
-  depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/coverage?source=conda-forge-mapping
-  size: 294192
-  timestamp: 1720731494473
-- kind: conda
-  name: coverage
-  version: 7.6.0
-  build: py310h5b4e0ec_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.0-py310h5b4e0ec_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.0-py310h5b4e0ec_0.conda
   sha256: 536aeb4327b835552b4f431b1e717a95c1d26eaac400a261c2dac43cd0a648a4
   md5: a13d72c877b47870042897a0e667cd3a
   depends:
@@ -2258,12 +1991,21 @@ packages:
   - pkg:pypi/coverage?source=conda-forge-mapping
   size: 292962
   timestamp: 1720730541413
-- kind: conda
-  name: cryptography
-  version: 40.0.2
-  build: py310h34c0648_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-40.0.2-py310h34c0648_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.6.0-py310h03727f4_0.conda
+  sha256: fce08e6b23aaa71b811abdda8c167c297e2adf26e9d4462372521daf4fe31246
+  md5: 3db345fdb61ed845c4dd25c50edf5d94
+  depends:
+  - libgcc-ng >=12
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/coverage?source=conda-forge-mapping
+  size: 294192
+  timestamp: 1720731494473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-40.0.2-py310h34c0648_0.conda
   sha256: 692b0394bb3104ec117faa0130d67109a0132e9bd57084ebfde81fc2b9790e58
   md5: 991a12eccbca3c9897c62f44b1104a54
   depends:
@@ -2278,12 +2020,7 @@ packages:
   - pkg:pypi/cryptography?source=conda-forge-mapping
   size: 1507114
   timestamp: 1681508937302
-- kind: conda
-  name: cryptography
-  version: 40.0.2
-  build: py310he4ba0b1_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-40.0.2-py310he4ba0b1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-40.0.2-py310he4ba0b1_0.conda
   sha256: d7ce6703be8cd729103a75c036455dcf345c0ccc764a33496355f1d8aebafb9f
   md5: 53666caf73d7633ddb3bf45f75b5afe9
   depends:
@@ -2299,33 +2036,7 @@ packages:
   - pkg:pypi/cryptography?source=conda-forge-mapping
   size: 1458231
   timestamp: 1681509013150
-- kind: conda
-  name: curl
-  version: 8.5.0
-  build: h4e8248e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.5.0-h4e8248e_0.conda
-  sha256: 8655abeadc854df4ca9cf60dd008fecf8d715e612e34d3cbaf3718cad2eee8a6
-  md5: 99c1fdb515d6ed1cbcd23e585f1475e8
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libcurl 8.5.0 h4e8248e_0
-  - libgcc-ng >=12
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  purls: []
-  size: 98437
-  timestamp: 1701860227762
-- kind: conda
-  name: curl
-  version: 8.5.0
-  build: hca28451_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/curl-8.5.0-hca28451_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.5.0-hca28451_0.conda
   sha256: febf098d6ca901b589d02c58eedcf5cb77d8fa4bfe35a52109f5909980b426db
   md5: e5e83fb15e752dbc8f54c4ac7da7d0f1
   depends:
@@ -2341,13 +2052,23 @@ packages:
   purls: []
   size: 94895
   timestamp: 1701860161671
-- kind: conda
-  name: cycler
-  version: 0.12.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.5.0-h4e8248e_0.conda
+  sha256: 8655abeadc854df4ca9cf60dd008fecf8d715e612e34d3cbaf3718cad2eee8a6
+  md5: 99c1fdb515d6ed1cbcd23e585f1475e8
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libcurl 8.5.0 h4e8248e_0
+  - libgcc-ng >=12
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 98437
+  timestamp: 1701860227762
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   md5: 5cd86562580f274031ede6aa6aa24441
   depends:
@@ -2358,19 +2079,12 @@ packages:
   - pkg:pypi/cycler?source=conda-forge-mapping
   size: 13458
   timestamp: 1696677888423
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl
   name: decorator
   version: 5.1.1
-  url: https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl
   sha256: b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186
   requires_python: '>=3.5'
-- kind: conda
-  name: deprecation
-  version: 2.1.0
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/deprecation-2.1.0-pyh9f0ad1d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/deprecation-2.1.0-pyh9f0ad1d_0.tar.bz2
   sha256: 2695a60ff355b114d0c459458461d941d2209ec9aff152853b6a3ca8700c94ec
   md5: 7b6747d7cc2076341029cff659669e8b
   depends:
@@ -2382,13 +2096,7 @@ packages:
   - pkg:pypi/deprecation?source=conda-forge-mapping
   size: 14487
   timestamp: 1589881524975
-- kind: conda
-  name: distro
-  version: 1.8.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
   md5: 67999c5465064480fa8016d00ac768f6
   depends:
@@ -2399,30 +2107,7 @@ packages:
   - pkg:pypi/distro?source=conda-forge-mapping
   size: 40854
   timestamp: 1675116355989
-- kind: conda
-  name: docutils
-  version: '0.19'
-  build: py310hbbe02a8_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.19-py310hbbe02a8_1.tar.bz2
-  sha256: 0ea888bcb7281d125e1173efb947780dd2f2bcf9a93661ef7d29d7cb8a167a0f
-  md5: 79059293c49d43008ec863e87673ec0e
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
-  purls:
-  - pkg:pypi/docutils?source=conda-forge-mapping
-  size: 782002
-  timestamp: 1666755645584
-- kind: conda
-  name: docutils
-  version: '0.19'
-  build: py310hff52083_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py310hff52083_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py310hff52083_1.tar.bz2
   sha256: f3a564449daedafe5931ab4efe7bc4f240182f2b760e7877f15b2898b7f1c988
   md5: 21b8fa2179290505e607f5ccd65b01b0
   depends:
@@ -2433,13 +2118,18 @@ packages:
   - pkg:pypi/docutils?source=conda-forge-mapping
   size: 780295
   timestamp: 1666755001794
-- kind: conda
-  name: exceptiongroup
-  version: 1.2.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.19-py310hbbe02a8_1.tar.bz2
+  sha256: 0ea888bcb7281d125e1173efb947780dd2f2bcf9a93661ef7d29d7cb8a167a0f
+  md5: 79059293c49d43008ec863e87673ec0e
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  purls:
+  - pkg:pypi/docutils?source=conda-forge-mapping
+  size: 782002
+  timestamp: 1666755645584
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
   sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
   md5: d02ae936e42063ca46af6cdad2dbd1e0
   depends:
@@ -2449,10 +2139,9 @@ packages:
   - pkg:pypi/exceptiongroup?source=conda-forge-mapping
   size: 20418
   timestamp: 1720869435725
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
   name: executing
   version: 2.0.1
-  url: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
   sha256: eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc
   requires_dist:
   - asttokens>=2.1.0 ; extra == 'tests'
@@ -2461,64 +2150,58 @@ packages:
   - coverage ; extra == 'tests'
   - coverage-enable-subprocess ; extra == 'tests'
   - littleutils ; extra == 'tests'
-  - rich ; python_version >= '3.11' and extra == 'tests'
+  - rich ; python_full_version >= '3.11' and extra == 'tests'
   requires_python: '>=3.5'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/9f/1a/8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310/Flask-2.2.5-py3-none-any.whl
   name: flask
   version: 2.2.5
-  url: https://files.pythonhosted.org/packages/9f/1a/8b6d48162861009d1e017a9740431c78d860809773b66cac220a11aa3310/Flask-2.2.5-py3-none-any.whl
   sha256: 58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf
   requires_dist:
   - werkzeug>=2.2.2
   - jinja2>=3.0
   - itsdangerous>=2.0
   - click>=8.0
-  - importlib-metadata>=3.6.0 ; python_version < '3.10'
+  - importlib-metadata>=3.6.0 ; python_full_version < '3.10'
   - asgiref>=3.2 ; extra == 'async'
   - python-dotenv ; extra == 'dotenv'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl
   name: flask-login
   version: 0.6.3
-  url: https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl
   sha256: 849b25b82a436bf830a054e74214074af59097171562ab10bfa999e6b78aae5d
   requires_dist:
   - flask>=1.0.4
   - werkzeug>=1.0.1
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/93/01/587023575286236f95d2ab8a826c320375ed5ea2102bb103ed89704ffa6b/Flask_Migrate-4.0.7-py3-none-any.whl
   name: flask-migrate
   version: 4.0.7
-  url: https://files.pythonhosted.org/packages/93/01/587023575286236f95d2ab8a826c320375ed5ea2102bb103ed89704ffa6b/Flask_Migrate-4.0.7-py3-none-any.whl
   sha256: 5c532be17e7b43a223b7500d620edae33795df27c75811ddf32560f7d48ec617
   requires_dist:
   - flask>=0.9
   - flask-sqlalchemy>=1.0
   - alembic>=1.9.0
   requires_python: '>=3.6'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/31/47/c0ad5f8fd6e9208b12018706c0da45fba3ad3042faffcdc5ae96114dc8ba/flask_shell_ipython-0.5.1-py2.py3-none-any.whl
   name: flask-shell-ipython
   version: 0.5.1
-  url: https://files.pythonhosted.org/packages/31/47/c0ad5f8fd6e9208b12018706c0da45fba3ad3042faffcdc5ae96114dc8ba/flask_shell_ipython-0.5.1-py2.py3-none-any.whl
   sha256: 8c948c0721bcc5b8eb274e1831c8a428dfc693099609c33d2f330091782cce10
   requires_dist:
   - flask>=1.0
   - click
   - ipython>=5.0.0
   requires_python: '>=3.6,<4'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl
   name: flask-sqlalchemy
   version: 3.1.1
-  url: https://files.pythonhosted.org/packages/1d/6a/89963a5c6ecf166e8be29e0d1bf6806051ee8fe6c82e232842e3aeac9204/flask_sqlalchemy-3.1.1-py3-none-any.whl
   sha256: 4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0
   requires_dist:
   - flask>=2.2.5
   - sqlalchemy>=2.0.16
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/7c/01/97ecc5174d35ec73d049bbea80b576e808e74dbd61af3a9aab6401515504/flask_wtf-1.1.2-py3-none-any.whl
   name: flask-wtf
   version: 1.1.2
-  url: https://files.pythonhosted.org/packages/7c/01/97ecc5174d35ec73d049bbea80b576e808e74dbd61af3a9aab6401515504/flask_wtf-1.1.2-py3-none-any.whl
   sha256: 134f45f3155ebdbb2b44fe8e5b498a0956d34a16b10a53fadcb7a865c0b3cea2
   requires_dist:
   - flask
@@ -2526,14 +2209,7 @@ packages:
   - wtforms
   - email-validator ; extra == 'email'
   requires_python: '>=3.8'
-- kind: conda
-  name: flit-core
-  version: 3.9.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_1.conda
   sha256: b417f3182e8d0ae142668a45136749507185d2736d4ff3b44dd924114d77b562
   md5: 5b722f5ce2fd3f2714e5a19f0d9178e3
   depends:
@@ -2546,12 +2222,7 @@ packages:
   - pkg:pypi/flit-core?source=conda-forge-mapping
   size: 49023
   timestamp: 1711371758852
-- kind: conda
-  name: fonttools
-  version: 4.53.1
-  build: py310h5b4e0ec_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py310h5b4e0ec_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py310h5b4e0ec_0.conda
   sha256: 704527a916f81811043921205a7aa4fc8463c6e1069c771ad51078290529e9a9
   md5: 2c5257cb35d1946f5e80a0cfd69ed7ec
   depends:
@@ -2568,12 +2239,7 @@ packages:
   - pkg:pypi/fonttools?source=conda-forge-mapping
   size: 2359986
   timestamp: 1720359222661
-- kind: conda
-  name: fonttools
-  version: 4.53.1
-  build: py310hb52b2da_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.53.1-py310hb52b2da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.53.1-py310hb52b2da_0.conda
   sha256: 6a1338b93480503816a2cc6775eabed7e5995c5a11229b40d22312528abf7c5a
   md5: 32ec9da7fa788f806405662d2921d039
   depends:
@@ -2590,13 +2256,7 @@ packages:
   - pkg:pypi/fonttools?source=conda-forge-mapping
   size: 2299511
   timestamp: 1720359415865
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: h267a509_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
   md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
   depends:
@@ -2607,13 +2267,7 @@ packages:
   purls: []
   size: 634972
   timestamp: 1694615932610
-- kind: conda
-  name: freetype
-  version: 2.12.1
-  build: hf0a5ef3_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
   sha256: 7af93030f4407f076dce181062360efac2cd54dce863b5d7765287a6f5382537
   md5: a5ab74c5bd158c3d5532b66d8d83d907
   depends:
@@ -2624,10 +2278,9 @@ packages:
   purls: []
   size: 642092
   timestamp: 1694617858496
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/1c/2f/64628f6ae48e05f585e0eb3fb7399b52e240ef99f602107b445bf6be23ef/greenlet-3.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: greenlet
   version: 3.0.3
-  url: https://files.pythonhosted.org/packages/1c/2f/64628f6ae48e05f585e0eb3fb7399b52e240ef99f602107b445bf6be23ef/greenlet-3.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83
   requires_dist:
   - sphinx ; extra == 'docs'
@@ -2635,10 +2288,9 @@ packages:
   - objgraph ; extra == 'test'
   - psutil ; extra == 'test'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/a6/d6/408ad9603339db28ce334021b1403dfcfbcb7501a435d49698408d928de7/greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: greenlet
   version: 3.0.3
-  url: https://files.pythonhosted.org/packages/a6/d6/408ad9603339db28ce334021b1403dfcfbcb7501a435d49698408d928de7/greenlet-3.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881
   requires_dist:
   - sphinx ; extra == 'docs'
@@ -2646,10 +2298,9 @@ packages:
   - objgraph ; extra == 'test'
   - psutil ; extra == 'test'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl
   name: gunicorn
   version: 20.1.0
-  url: https://files.pythonhosted.org/packages/e4/dd/5b190393e6066286773a67dfcc2f9492058e9b57c4867a95f1ba5caf0a83/gunicorn-20.1.0-py3-none-any.whl
   sha256: 9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e
   requires_dist:
   - setuptools>=3.0
@@ -2658,12 +2309,7 @@ packages:
   - setproctitle ; extra == 'setproctitle'
   - tornado>=0.2 ; extra == 'tornado'
   requires_python: '>=3.5'
-- kind: conda
-  name: icu
-  version: '70.1'
-  build: h27087fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-70.1-h27087fc_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-70.1-h27087fc_0.tar.bz2
   sha256: 1d7950f3be4637ab915d886304e57731d39a41ab705ffc95c4681655c459374a
   md5: 87473a15119779e021c314249d4b4aed
   depends:
@@ -2674,19 +2320,12 @@ packages:
   purls: []
   size: 14191488
   timestamp: 1648050221778
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
   name: idna
   version: '3.7'
-  url: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
   sha256: 82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
   requires_python: '>=3.5'
-- kind: conda
-  name: importlib-metadata
-  version: 8.2.0
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
   sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
   md5: c261d14fc7f49cdd403868998a18c318
   depends:
@@ -2698,19 +2337,12 @@ packages:
   - pkg:pypi/importlib-metadata?source=conda-forge-mapping
   size: 28110
   timestamp: 1721856614564
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl
   name: inflection
   version: 0.5.1
-  url: https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl
   sha256: f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2
   requires_python: '>=3.5'
-- kind: conda
-  name: iniconfig
-  version: 2.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
   sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
   md5: f800d2da156d08e289b14e87e43c1ae5
   depends:
@@ -2721,21 +2353,20 @@ packages:
   - pkg:pypi/iniconfig?source=conda-forge-mapping
   size: 11101
   timestamp: 1673103208955
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/7a/57/ef12725f8af19920db1d8f2eaee44ebbaee6d9fdcf853be5db76bfdb9ce6/ipython-8.18.0-py3-none-any.whl
   name: ipython
   version: 8.18.0
-  url: https://files.pythonhosted.org/packages/7a/57/ef12725f8af19920db1d8f2eaee44ebbaee6d9fdcf853be5db76bfdb9ce6/ipython-8.18.0-py3-none-any.whl
   sha256: d538a7a98ad9b7e018926447a5f35856113a85d08fd68a165d7871ab5175f6e0
   requires_dist:
   - decorator
   - jedi>=0.16
   - matplotlib-inline
-  - prompt-toolkit!=3.0.37,<3.1.0,>=3.0.30
+  - prompt-toolkit>=3.0.30,!=3.0.37,<3.1.0
   - pygments>=2.4.0
   - stack-data
   - traitlets>=5
-  - typing-extensions ; python_version < '3.10'
-  - exceptiongroup ; python_version < '3.11'
+  - typing-extensions ; python_full_version < '3.10'
+  - exceptiongroup ; python_full_version < '3.11'
   - pexpect>4.3 ; sys_platform != 'win32'
   - colorama ; sys_platform == 'win32'
   - black ; extra == 'all'
@@ -2801,19 +2432,17 @@ packages:
   - pandas ; extra == 'test-extra'
   - trio ; extra == 'test-extra'
   requires_python: '>=3.9'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
   name: itsdangerous
   version: 2.2.0
-  url: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
   sha256: c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
   name: jedi
   version: 0.19.1
-  url: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
   sha256: e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0
   requires_dist:
-  - parso<0.9.0,>=0.8.3
+  - parso>=0.8.3,<0.9.0
   - jinja2==2.11.3 ; extra == 'docs'
   - markupsafe==1.1.1 ; extra == 'docs'
   - pygments==2.8.1 ; extra == 'docs'
@@ -2848,22 +2477,15 @@ packages:
   - docopt ; extra == 'testing'
   - pytest<7.0.0 ; extra == 'testing'
   requires_python: '>=3.6'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
   name: jinja2
   version: 3.1.4
-  url: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
   sha256: bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
   requires_dist:
   - markupsafe>=2.0
   - babel>=2.7 ; extra == 'i18n'
   requires_python: '>=3.7'
-- kind: conda
-  name: jmespath
-  version: 1.0.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
   sha256: 95ac5f9ee95fd4e34dc051746fc86016d3d4f6abefed113e2ede049d59ec2991
   md5: 2cfa3e1cf3fb51bb9b17acc5b5e9ea11
   depends:
@@ -2874,18 +2496,17 @@ packages:
   - pkg:pypi/jmespath?source=conda-forge-mapping
   size: 21003
   timestamp: 1655568358125
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl
   name: jsonschema
   version: 4.17.3
-  url: https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl
   sha256: a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6
   requires_dist:
   - attrs>=17.4.0
-  - importlib-metadata ; python_version < '3.8'
-  - importlib-resources>=1.4.0 ; python_version < '3.9'
-  - pkgutil-resolve-name>=1.3.10 ; python_version < '3.9'
-  - pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-  - typing-extensions ; python_version < '3.8'
+  - importlib-metadata ; python_full_version < '3.8'
+  - importlib-resources>=1.4.0 ; python_full_version < '3.9'
+  - pkgutil-resolve-name>=1.3.10 ; python_full_version < '3.9'
+  - pyrsistent>=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
+  - typing-extensions ; python_full_version < '3.8'
   - fqdn ; extra == 'format'
   - idna ; extra == 'format'
   - isoduration ; extra == 'format'
@@ -2903,24 +2524,18 @@ packages:
   - uri-template ; extra == 'format-nongpl'
   - webcolors>=1.11 ; extra == 'format-nongpl'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/52/18/0c62b011d64158c2420594002f58b3ad30a8e982bf8e6b4f078df9e95b9b/jsonschema_spec-0.1.6-py3-none-any.whl
   name: jsonschema-spec
   version: 0.1.6
-  url: https://files.pythonhosted.org/packages/52/18/0c62b011d64158c2420594002f58b3ad30a8e982bf8e6b4f078df9e95b9b/jsonschema_spec-0.1.6-py3-none-any.whl
   sha256: f2206d18c89d1824c1f775ba14ed039743b41a9167bd2c5bdb774b66b3ca0bbf
   requires_dist:
   - pyyaml>=5.1
   - jsonschema>=4.0.0,<4.18.0
   - pathable>=0.4.1,<0.5.0
   - requests>=2.31.0,<3.0.0
-  - typing-extensions<4.6.0 ; python_version < '3.8'
+  - typing-extensions<4.6.0 ; python_full_version < '3.8'
   requires_python: '>=3.7.0,<4.0.0'
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
   sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
   md5: 30186d27e2c9fa62b45fb1476b7200e3
   depends:
@@ -2929,12 +2544,7 @@ packages:
   purls: []
   size: 117831
   timestamp: 1646151697040
-- kind: conda
-  name: keyutils
-  version: 1.6.1
-  build: h4e544f5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
   sha256: 6d4233d97a9b38acbb26e1268bcf8c10a8e79c2aed7e5a385ec3769967e3e65b
   md5: 1f24853e59c68892452ef94ddd8afd4b
   depends:
@@ -2943,13 +2553,7 @@ packages:
   purls: []
   size: 112327
   timestamp: 1646166857935
-- kind: conda
-  name: kiwisolver
-  version: 1.4.5
-  build: py310hd41b1e2_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
   sha256: bb51906639bced3de1d4d7740ac284cdaa89e2f22e0b1ec796378b090b0648ba
   md5: b8d67603d43b23ce7e988a5d81a7ab79
   depends:
@@ -2963,13 +2567,7 @@ packages:
   - pkg:pypi/kiwisolver?source=conda-forge-mapping
   size: 73123
   timestamp: 1695380074542
-- kind: conda
-  name: kiwisolver
-  version: 1.4.5
-  build: py310he290b8a_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.4.5-py310he290b8a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.4.5-py310he290b8a_1.conda
   sha256: 302751fae90ffb42166a869c468c5ce38bea106573fbe10ac57bd0c46cf1585d
   md5: 7acac786ac8778122238891b0cc1614e
   depends:
@@ -2983,62 +2581,36 @@ packages:
   - pkg:pypi/kiwisolver?source=conda-forge-mapping
   size: 72694
   timestamp: 1695381232299
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/b4/9a/1951f2261271d6994f0df5a55b3e9cdad42ed1fc3020a0dc7f6de80a4566/kombu-5.3.7-py3-none-any.whl
   name: kombu
   version: 5.3.7
-  url: https://files.pythonhosted.org/packages/b4/9a/1951f2261271d6994f0df5a55b3e9cdad42ed1fc3020a0dc7f6de80a4566/kombu-5.3.7-py3-none-any.whl
   sha256: 5634c511926309c7f9789f1433e9ed402616b56836ef9878f01bd59267b4c7a9
   requires_dist:
-  - amqp<6.0.0,>=5.1.1
+  - amqp>=5.1.1,<6.0.0
   - vine
-  - typing-extensions ; python_version < '3.10'
-  - backports-zoneinfo[tzdata]>=0.2.1 ; python_version < '3.9'
+  - typing-extensions ; python_full_version < '3.10'
+  - backports-zoneinfo[tzdata]>=0.2.1 ; python_full_version < '3.9'
   - azure-servicebus>=7.10.0 ; extra == 'azureservicebus'
   - azure-storage-queue>=12.6.0 ; extra == 'azurestoragequeues'
   - azure-identity>=1.12.0 ; extra == 'azurestoragequeues'
   - confluent-kafka>=2.2.0 ; extra == 'confluentkafka'
   - python-consul2 ; extra == 'consul'
-  - librabbitmq>=2.0.0 ; python_version < '3.11' and extra == 'librabbitmq'
+  - librabbitmq>=2.0.0 ; python_full_version < '3.11' and extra == 'librabbitmq'
   - pymongo>=4.1.1 ; extra == 'mongodb'
   - msgpack ; extra == 'msgpack'
   - pyro4 ; extra == 'pyro'
   - qpid-python>=0.26 ; extra == 'qpid'
   - qpid-tools>=0.26 ; extra == 'qpid'
-  - redis!=4.5.5,!=5.0.2,>=4.5.2 ; extra == 'redis'
+  - redis>=4.5.2,!=4.5.5,!=5.0.2 ; extra == 'redis'
   - softlayer-messaging>=1.0.3 ; extra == 'slmq'
-  - sqlalchemy<2.1,>=1.4.48 ; extra == 'sqlalchemy'
+  - sqlalchemy>=1.4.48,<2.1 ; extra == 'sqlalchemy'
   - boto3>=1.26.143 ; extra == 'sqs'
   - urllib3>=1.26.16 ; extra == 'sqs'
-  - pycurl>=7.43.0.5 ; (sys_platform != 'win32' and platform_python_implementation == 'CPython') and extra == 'sqs'
+  - pycurl>=7.43.0.5 ; platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'sqs'
   - pyyaml>=3.10 ; extra == 'yaml'
   - kazoo>=2.8.0 ; extra == 'zookeeper'
   requires_python: '>=3.8'
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h50a48e9_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
-  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
-  md5: 29c10432a2ca1472b53f299ffb2ffa37
-  depends:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.3.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1474620
-  timestamp: 1719463205834
-- kind: conda
-  name: krb5
-  version: 1.21.3
-  build: h659f571_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
   depends:
@@ -3053,41 +2625,32 @@ packages:
   purls: []
   size: 1370023
   timestamp: 1719463201255
-- kind: pypi
-  name: lazy-object-proxy
-  version: 1.10.0
-  url: https://files.pythonhosted.org/packages/4a/0d/b325461e43dde8d7644e9b9e9dd57f2a4af472b588c51ccbc92778e60ea4/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  sha256: 7ab7004cf2e59f7c2e4345604a3e6ea0d92ac44e1c2375527d56492014e690c3
-  requires_python: '>=3.8'
-- kind: pypi
-  name: lazy-object-proxy
-  version: 1.10.0
-  url: https://files.pythonhosted.org/packages/8b/fc/83711d743fb5aaca5747bbf225fe3b5cbe085c7f6c115856b5cce80f3224/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: dc0d2fc424e54c70c4bc06787e4072c4f3b1aa2f897dfdc34ce1013cf3ceef05
-  requires_python: '>=3.8'
-- kind: conda
-  name: lcms2
-  version: '2.16'
-  build: h922389a_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.16-h922389a_0.conda
-  sha256: be4847b1014d3cbbc524a53bdbf66182f86125775020563e11d914c8468dd97d
-  md5: ffdd8267a04c515e7ce69c727b051414
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.3-h50a48e9_0.conda
+  sha256: 0ec272afcf7ea7fbf007e07a3b4678384b7da4047348107b2ae02630a570a815
+  md5: 29c10432a2ca1472b53f299ffb2ffa37
   depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
   - libgcc-ng >=12
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 296219
-  timestamp: 1701647961116
-- kind: conda
-  name: lcms2
-  version: '2.16'
-  build: hb7c19ff_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+  size: 1474620
+  timestamp: 1719463205834
+- pypi: https://files.pythonhosted.org/packages/4a/0d/b325461e43dde8d7644e9b9e9dd57f2a4af472b588c51ccbc92778e60ea4/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  name: lazy-object-proxy
+  version: 1.10.0
+  sha256: 7ab7004cf2e59f7c2e4345604a3e6ea0d92ac44e1c2375527d56492014e690c3
+  requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/8b/fc/83711d743fb5aaca5747bbf225fe3b5cbe085c7f6c115856b5cce80f3224/lazy_object_proxy-1.10.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: lazy-object-proxy
+  version: 1.10.0
+  sha256: dc0d2fc424e54c70c4bc06787e4072c4f3b1aa2f897dfdc34ce1013cf3ceef05
+  requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
   sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
   md5: 51bb7010fc86f70eee639b4bb7a894f5
   depends:
@@ -3099,13 +2662,19 @@ packages:
   purls: []
   size: 245247
   timestamp: 1701647787198
-- kind: conda
-  name: ld_impl_linux-64
-  version: '2.40'
-  build: hf3520f5_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.16-h922389a_0.conda
+  sha256: be4847b1014d3cbbc524a53bdbf66182f86125775020563e11d914c8468dd97d
+  md5: ffdd8267a04c515e7ce69c727b051414
+  depends:
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 296219
+  timestamp: 1701647961116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
   sha256: 764b6950aceaaad0c67ef925417594dd14cd2e22fff864aeef455ac259263d15
   md5: b80f2f396ca2c28b8c14c437a4ed1e74
   constrains:
@@ -3115,13 +2684,7 @@ packages:
   purls: []
   size: 707602
   timestamp: 1718625640445
-- kind: conda
-  name: ld_impl_linux-aarch64
-  version: '2.40'
-  build: h9fc2d93_7
-  build_number: 7
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h9fc2d93_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h9fc2d93_7.conda
   sha256: 4a6c0bd77e125da8472bd73bba7cd4169a3ce4699b00a3893026ae8664b2387d
   md5: 1b0feef706f4d03eff0b76626ead64fc
   constrains:
@@ -3131,12 +2694,7 @@ packages:
   purls: []
   size: 735885
   timestamp: 1718625653417
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h27087fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
   sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
   md5: 76bbff344f0134279f225174e9064c8f
   depends:
@@ -3147,12 +2705,7 @@ packages:
   purls: []
   size: 281798
   timestamp: 1657977462600
-- kind: conda
-  name: lerc
-  version: 4.0.0
-  build: h4de3ea5_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
   sha256: 2d09ef9b7796d83364957e420b41c32d94e628c3f0520b61c332518a7b5cd586
   md5: 1a0ffc65e03ce81559dbcb0695ad1476
   depends:
@@ -3163,13 +2716,8 @@ packages:
   purls: []
   size: 262096
   timestamp: 1657978241894
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 23_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
   build_number: 23
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
   sha256: edb1cee5da3ac4936940052dcab6969673ba3874564f90f5110f8c11eed789c2
   md5: 96c8450a40aa2b9733073a9460de972c
   depends:
@@ -3185,13 +2733,8 @@ packages:
   purls: []
   size: 14880
   timestamp: 1721688759937
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 23_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-23_linuxaarch64_openblas.conda
   build_number: 23
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-23_linuxaarch64_openblas.conda
   sha256: 17d90edd4742fbee0bcafb4f12d08dd5d1939b12a9c2f21caccfa3717fcab065
   md5: 3ac1ad627e1a07fae62556d6aabafdfd
   depends:
@@ -3207,29 +2750,7 @@ packages:
   purls: []
   size: 14917
   timestamp: 1721688777901
-- kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h31becfc_1.conda
-  sha256: 1c3d4ea61e862eb5f1968915f6f5917ea61db9921aec30b14785775c87234060
-  md5: 1b219fd801eddb7a94df5bd001053ad9
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 69237
-  timestamp: 1695990107496
-- kind: conda
-  name: libbrotlicommon
-  version: 1.1.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
   sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
   md5: aec6c91c7371c26392a06708a73c70e5
   depends:
@@ -3239,30 +2760,17 @@ packages:
   purls: []
   size: 69403
   timestamp: 1695990007212
-- kind: conda
-  name: libbrotlidec
-  version: 1.1.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h31becfc_1.conda
-  sha256: 1d2558efbb727f9065dd94d5f906aa68252153f80e571456d3695fa102e8a352
-  md5: 8db7cff89510bec0b863a0a8ee6a7bce
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h31becfc_1.conda
+  sha256: 1c3d4ea61e862eb5f1968915f6f5917ea61db9921aec30b14785775c87234060
+  md5: 1b219fd801eddb7a94df5bd001053ad9
   depends:
-  - libbrotlicommon 1.1.0 h31becfc_1
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 31926
-  timestamp: 1695990123189
-- kind: conda
-  name: libbrotlidec
-  version: 1.1.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+  size: 69237
+  timestamp: 1695990107496
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
   sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
   md5: f07002e225d7a60a694d42a7bf5ff53f
   depends:
@@ -3273,30 +2781,18 @@ packages:
   purls: []
   size: 32775
   timestamp: 1695990022788
-- kind: conda
-  name: libbrotlienc
-  version: 1.1.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-h31becfc_1.conda
-  sha256: 271fd8ef9181ad19246bf8b4273c99b9608c6eedecb6b11cd925211b8f1c6217
-  md5: ad3d3a826b5848d99936e4466ebbaa26
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h31becfc_1.conda
+  sha256: 1d2558efbb727f9065dd94d5f906aa68252153f80e571456d3695fa102e8a352
+  md5: 8db7cff89510bec0b863a0a8ee6a7bce
   depends:
   - libbrotlicommon 1.1.0 h31becfc_1
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 290542
-  timestamp: 1695990138784
-- kind: conda
-  name: libbrotlienc
-  version: 1.1.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+  size: 31926
+  timestamp: 1695990123189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
   sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
   md5: 5fc11c6020d421960607d821310fcd4d
   depends:
@@ -3307,13 +2803,19 @@ packages:
   purls: []
   size: 282523
   timestamp: 1695990038302
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 23_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-h31becfc_1.conda
+  sha256: 271fd8ef9181ad19246bf8b4273c99b9608c6eedecb6b11cd925211b8f1c6217
+  md5: ad3d3a826b5848d99936e4466ebbaa26
+  depends:
+  - libbrotlicommon 1.1.0 h31becfc_1
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 290542
+  timestamp: 1695990138784
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-23_linux64_openblas.conda
   build_number: 23
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-23_linux64_openblas.conda
   sha256: 3e7a3236e7e03e308e1667d91d0aa70edd0cba96b4b5563ef4adde088e0881a5
   md5: eede29b40efa878cbe5bdcb767e97310
   depends:
@@ -3327,13 +2829,8 @@ packages:
   purls: []
   size: 14798
   timestamp: 1721688767584
-- kind: conda
-  name: libcblas
-  version: 3.9.0
-  build: 23_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-23_linuxaarch64_openblas.conda
   build_number: 23
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-23_linuxaarch64_openblas.conda
   sha256: a885bc11fcbe568a7abaff1188f1713b8709e35382606e6ee2cf7cfed6a0b6de
   md5: 65a4f18036c0f5419146fddee6653a96
   depends:
@@ -3347,33 +2844,7 @@ packages:
   purls: []
   size: 14828
   timestamp: 1721688783578
-- kind: conda
-  name: libcurl
-  version: 8.5.0
-  build: h4e8248e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
-  sha256: 4f4f8b884927d0c6fad4a8f5d7afaf789fe4f6554448ac8b416231f2f3dc7490
-  md5: fa0f5edc06ffc25a01eed005c6dc3d8c
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  purls: []
-  size: 399469
-  timestamp: 1701860213311
-- kind: conda
-  name: libcurl
-  version: 8.5.0
-  build: hca28451_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
   sha256: 00a6bea5ff90ca58eeb15ebc98e08ffb88bddaff27396bb62640064f59d29cf0
   md5: 7144d5a828e2cae218e0e3c98d8a0aeb
   depends:
@@ -3389,27 +2860,23 @@ packages:
   purls: []
   size: 389164
   timestamp: 1701860147844
-- kind: conda
-  name: libdeflate
-  version: '1.20'
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.20-h31becfc_0.conda
-  sha256: 01efbc296d47de9861100d9a9ad2c7f682adc71a0e9b9b040a35b454d1ccd3bd
-  md5: 018592a3d691662f451f89d0de474a20
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
+  sha256: 4f4f8b884927d0c6fad4a8f5d7afaf789fe4f6554448ac8b416231f2f3dc7490
+  md5: fa0f5edc06ffc25a01eed005c6dc3d8c
   depends:
+  - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
-  license: MIT
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
   license_family: MIT
   purls: []
-  size: 69943
-  timestamp: 1711196586503
-- kind: conda
-  name: libdeflate
-  version: '1.20'
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
+  size: 399469
+  timestamp: 1701860213311
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
   sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
   md5: 8e88f9389f1165d7c0936fe40d9a9a79
   depends:
@@ -3419,13 +2886,17 @@ packages:
   purls: []
   size: 71500
   timestamp: 1711196523408
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.20-h31becfc_0.conda
+  sha256: 01efbc296d47de9861100d9a9ad2c7f682adc71a0e9b9b040a35b454d1ccd3bd
+  md5: 018592a3d691662f451f89d0de474a20
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 69943
+  timestamp: 1711196586503
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
   md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
   depends:
@@ -3436,13 +2907,7 @@ packages:
   purls: []
   size: 123878
   timestamp: 1597616541093
-- kind: conda
-  name: libedit
-  version: 3.1.20191231
-  build: he28a2e2_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   sha256: debc31fb2f07ba2b0363f90e455873670734082822926ba4a9556431ec0bf36d
   md5: 29371161d77933a54fccf1bb66b96529
   depends:
@@ -3453,29 +2918,7 @@ packages:
   purls: []
   size: 134104
   timestamp: 1597617110769
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: h31becfc_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
-  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
-  md5: a9a13cb143bbaa477b1ebaefbe47a302
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 115123
-  timestamp: 1702146237623
-- kind: conda
-  name: libev
-  version: '4.33'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
   depends:
@@ -3485,29 +2928,17 @@ packages:
   purls: []
   size: 112766
   timestamp: 1702146165126
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h3557bc0_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
-  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
-  md5: dddd85f4d52121fab0a8b099c5e06501
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+  sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+  md5: a9a13cb143bbaa477b1ebaefbe47a302
   depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
   purls: []
-  size: 59450
-  timestamp: 1636488255090
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h7f98852_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  size: 115123
+  timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
@@ -3517,12 +2948,17 @@ packages:
   purls: []
   size: 58292
   timestamp: 1636488182923
-- kind: conda
-  name: libgcc-ng
-  version: 14.1.0
-  build: h77fa898_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
+  sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
+  md5: dddd85f4d52121fab0a8b099c5e06501
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 59450
+  timestamp: 1636488255090
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
   sha256: b8e869ac96591cda2704bf7e77a301025e405227791a0bddf14a3dac65125538
   md5: ca0fad6a41ddaef54a153b78eccb5037
   depends:
@@ -3535,12 +2971,7 @@ packages:
   purls: []
   size: 842109
   timestamp: 1719538896937
-- kind: conda
-  name: libgcc-ng
-  version: 14.1.0
-  build: he277a41_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-14.1.0-he277a41_0.conda
   sha256: b9ca03216bc089c0c46f008bc6f447bc0df8dc826d9801fb4283e49fa89c877e
   md5: 47ecd1292a3fd78b616640b35dd9632c
   depends:
@@ -3552,12 +2983,7 @@ packages:
   purls: []
   size: 532273
   timestamp: 1719547536460
-- kind: conda
-  name: libgfortran-ng
-  version: 14.1.0
-  build: h69a702a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
   sha256: ef624dacacf97b2b0af39110b36e2fd3e39e358a1a6b7b21b85c9ac22d8ffed9
   md5: f4ca84fbd6d06b0a052fb2d5b96dde41
   depends:
@@ -3567,12 +2993,7 @@ packages:
   purls: []
   size: 49893
   timestamp: 1719538933879
-- kind: conda
-  name: libgfortran-ng
-  version: 14.1.0
-  build: he9431aa_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.1.0-he9431aa_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-14.1.0-he9431aa_0.conda
   sha256: 72d7aa3d0b20b9d64a2f1c72f016c5a8a19594bb56857267e9fc7c1fc0f13223
   md5: a50ae662c1e7f26f0f2c99e31d1bf614
   depends:
@@ -3582,29 +3003,7 @@ packages:
   purls: []
   size: 50098
   timestamp: 1719547575524
-- kind: conda
-  name: libgfortran5
-  version: 14.1.0
-  build: h9420597_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.1.0-h9420597_0.conda
-  sha256: 34a339c50c0fd2944ea31a013336b500f91f2e00ccfa0607f1bcc5d0a3378373
-  md5: b907b29b964b8ebd7be215e47a659179
-  depends:
-  - libgcc-ng >=14.1.0
-  constrains:
-  - libgfortran-ng 14.1.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 1099210
-  timestamp: 1719547548899
-- kind: conda
-  name: libgfortran5
-  version: 14.1.0
-  build: hc5f4f2c_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
   sha256: a67d66b1e60a8a9a9e4440cee627c959acb4810cb182e089a4b0729bfdfbdf90
   md5: 6456c2620c990cd8dde2428a27ba0bc5
   depends:
@@ -3616,12 +3015,19 @@ packages:
   purls: []
   size: 1457561
   timestamp: 1719538909168
-- kind: conda
-  name: libgomp
-  version: 14.1.0
-  build: h77fa898_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-14.1.0-h9420597_0.conda
+  sha256: 34a339c50c0fd2944ea31a013336b500f91f2e00ccfa0607f1bcc5d0a3378373
+  md5: b907b29b964b8ebd7be215e47a659179
+  depends:
+  - libgcc-ng >=14.1.0
+  constrains:
+  - libgfortran-ng 14.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1099210
+  timestamp: 1719547548899
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
   sha256: 7699df61a1f6c644b3576a40f54791561f2845983120477a16116b951c9cdb05
   md5: ae061a5ed5f05818acdf9adab72c146d
   depends:
@@ -3631,12 +3037,7 @@ packages:
   purls: []
   size: 456925
   timestamp: 1719538796073
-- kind: conda
-  name: libgomp
-  version: 14.1.0
-  build: he277a41_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-14.1.0-he277a41_0.conda
   sha256: 11f326e49e0fb92c2a52e870c029fc26b4b6d3eb9414fa4374cb8496b231a730
   md5: 434ccc943b843117e4cebc97265f2504
   license: GPL-3.0-only WITH GCC-exception-3.1
@@ -3644,13 +3045,7 @@ packages:
   purls: []
   size: 459535
   timestamp: 1719547432949
-- kind: conda
-  name: libiconv
-  version: '1.17'
-  build: hd590300_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
   sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
   md5: d66573916ffcf376178462f1b61c941e
   depends:
@@ -3659,30 +3054,7 @@ packages:
   purls: []
   size: 705775
   timestamp: 1702682170569
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
-  sha256: 675bc1f2a8581cd34a86c412663ec29c5f90c1d9f8d11866aa1ade5cdbdf8429
-  md5: ed24e702928be089d9ba3f05618515c6
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  purls: []
-  size: 647126
-  timestamp: 1694475003570
-- kind: conda
-  name: libjpeg-turbo
-  version: 3.0.0
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
   sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
   md5: ea25936bb4080d843790b586850f82b8
   depends:
@@ -3693,13 +3065,19 @@ packages:
   purls: []
   size: 618575
   timestamp: 1694474974816
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 23_linux64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
+  sha256: 675bc1f2a8581cd34a86c412663ec29c5f90c1d9f8d11866aa1ade5cdbdf8429
+  md5: ed24e702928be089d9ba3f05618515c6
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  size: 647126
+  timestamp: 1694475003570
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-23_linux64_openblas.conda
   build_number: 23
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-23_linux64_openblas.conda
   sha256: 25c7aef86c8a1d9db0e8ee61aa7462ba3b46b482027a65d66eb83e3e6f949043
   md5: 2af0879961951987e464722fd00ec1e0
   depends:
@@ -3713,13 +3091,8 @@ packages:
   purls: []
   size: 14823
   timestamp: 1721688775172
-- kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 23_linuxaarch64_openblas
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-23_linuxaarch64_openblas.conda
   build_number: 23
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-23_linuxaarch64_openblas.conda
   sha256: e38af4037789e0650755d6d2758f49ef6820ddf67e9aee633abfad6f281a17cb
   md5: 85c4fec3847027ca7402f3bd7d2de4c1
   depends:
@@ -3733,13 +3106,7 @@ packages:
   purls: []
   size: 14848
   timestamp: 1721688789196
-- kind: conda
-  name: libnghttp2
-  version: 1.58.0
-  build: h47da74e_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
   sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
   md5: 700ac6ea6d53d5510591c4344d5c989a
   depends:
@@ -3755,13 +3122,7 @@ packages:
   purls: []
   size: 631936
   timestamp: 1702130036271
-- kind: conda
-  name: libnghttp2
-  version: 1.58.0
-  build: hb0e430d_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
   sha256: ecc11e4f92f9d5830a90d42b4db55c66c4ad531e00dcf30d55171d934a568cb5
   md5: 8f724cdddffa79152de61f5564a3526b
   depends:
@@ -3777,27 +3138,7 @@ packages:
   purls: []
   size: 677508
   timestamp: 1702130071743
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
-  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
-  md5: c14f32510f694e3185704d89967ec422
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  license_family: GPL
-  purls: []
-  size: 34501
-  timestamp: 1697358973269
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
   sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
@@ -3807,33 +3148,17 @@ packages:
   purls: []
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libopenblas
-  version: 0.3.27
-  build: pthreads_h076ed1e_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.27-pthreads_h076ed1e_1.conda
-  sha256: 17b74989b2c94d6427d6c3a7a0b7d8e28e1ce34928b021773a1242c10b86d72e
-  md5: cc0a15e3a6f92f454b6132ca6aca8e8d
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
+  sha256: fd18c2b75d7411096428d36a70b36b1a17e31f7b8956b6905d145792d49e97f8
+  md5: c14f32510f694e3185704d89967ec422
   depends:
   - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  constrains:
-  - openblas >=0.3.27,<0.3.28.0a0
-  license: BSD-3-Clause
-  license_family: BSD
+  license: LGPL-2.1-only
+  license_family: GPL
   purls: []
-  size: 4290434
-  timestamp: 1720425850976
-- kind: conda
-  name: libopenblas
-  version: 0.3.27
-  build: pthreads_hac2b453_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
+  size: 34501
+  timestamp: 1697358973269
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
   sha256: 714cb82d7c4620ea2635a92d3df263ab841676c9b183d0c01992767bb2451c39
   md5: ae05ece66d3924ac3d48b4aa3fa96cec
   depends:
@@ -3847,27 +3172,21 @@ packages:
   purls: []
   size: 5563053
   timestamp: 1720426334043
-- kind: conda
-  name: libpng
-  version: 1.6.43
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
-  sha256: 6f408f3d6854f86e223289f0dda12562b047c7a1fdf3636c67ec39afcd141f43
-  md5: 1123e504d9254dd9494267ab9aba95f0
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.27-pthreads_h076ed1e_1.conda
+  sha256: 17b74989b2c94d6427d6c3a7a0b7d8e28e1ce34928b021773a1242c10b86d72e
+  md5: cc0a15e3a6f92f454b6132ca6aca8e8d
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: zlib-acknowledgement
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.27,<0.3.28.0a0
+  license: BSD-3-Clause
+  license_family: BSD
   purls: []
-  size: 294380
-  timestamp: 1708782876525
-- kind: conda
-  name: libpng
-  version: 1.6.43
-  build: h2797004_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+  size: 4290434
+  timestamp: 1720425850976
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
   sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
   md5: 009981dd9cfcaa4dbfa25ffaed86bcae
   depends:
@@ -3877,12 +3196,17 @@ packages:
   purls: []
   size: 288221
   timestamp: 1708780443939
-- kind: conda
-  name: libpq
-  version: '16.3'
-  build: ha72fbe1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
+  sha256: 6f408f3d6854f86e223289f0dda12562b047c7a1fdf3636c67ec39afcd141f43
+  md5: 1123e504d9254dd9494267ab9aba95f0
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 294380
+  timestamp: 1708782876525
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
   sha256: 117ba1e11f07b1ca0671641bd6d1f2e7fc6e27db1c317a0cdb4799ffa69f47db
   md5: bac737ae28b79cfbafd515258d97d29e
   depends:
@@ -3893,12 +3217,7 @@ packages:
   purls: []
   size: 2500439
   timestamp: 1715266400833
-- kind: conda
-  name: libpq
-  version: '16.3'
-  build: hcf0348d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.3-hcf0348d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.3-hcf0348d_0.conda
   sha256: 8f4f0be9e86cce1a51423ccb9bfe559fb3778e2c2d62176ee52c31a029cc8d6d
   md5: 7dd46e914b037824b9a9629ca6586fc3
   depends:
@@ -3909,12 +3228,7 @@ packages:
   purls: []
   size: 2539253
   timestamp: 1715266429766
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
-  build: hde9e2c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
   sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
   md5: 18aa975d2094c34aef978060ae7da7d8
   depends:
@@ -3924,12 +3238,7 @@ packages:
   purls: []
   size: 865346
   timestamp: 1718050628718
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
-  build: hf51ef55_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.0-hf51ef55_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.0-hf51ef55_0.conda
   sha256: 7b48d006be6cd089105687fb524a2c93c4218bfc398d0611340cafec55249977
   md5: a8ae63fd6fb7d007f74ef3df95e5edf3
   depends:
@@ -3939,12 +3248,7 @@ packages:
   purls: []
   size: 1043861
   timestamp: 1718050586624
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h0841786_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
   sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
   md5: 1f5a58e686b13bcfde88b93f547d23fe
   depends:
@@ -3956,12 +3260,7 @@ packages:
   purls: []
   size: 271133
   timestamp: 1685837707056
-- kind: conda
-  name: libssh2
-  version: 1.11.0
-  build: h492db2e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
   sha256: 409163dd4a888b9266369f1bce57b5ca56c216e34249637c3e10eb404e356171
   md5: 45532845e121677ad328c9af9953f161
   depends:
@@ -3973,27 +3272,7 @@ packages:
   purls: []
   size: 284335
   timestamp: 1685837600415
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.1.0
-  build: h3f4de04_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-h3f4de04_0.conda
-  sha256: 4f2f35b78258d1a1e56b1b0e61091862c10ec76bf67ca1b0ff99dd5e07e76271
-  md5: 2f84852b723ac4389eb188db695526bb
-  depends:
-  - libgcc-ng 14.1.0 he277a41_0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  purls: []
-  size: 3805250
-  timestamp: 1719547563542
-- kind: conda
-  name: libstdcxx-ng
-  version: 14.1.0
-  build: hc0a3c3a_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
   sha256: 88c42b388202ffe16adaa337e36cf5022c63cf09b0405cf06fc6aeacccbe6146
   md5: 1cb187a157136398ddbaae90713e2498
   depends:
@@ -4003,13 +3282,17 @@ packages:
   purls: []
   size: 3881307
   timestamp: 1719538923443
-- kind: conda
-  name: libtiff
-  version: 4.6.0
-  build: h1dd3fc0_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.1.0-h3f4de04_0.conda
+  sha256: 4f2f35b78258d1a1e56b1b0e61091862c10ec76bf67ca1b0ff99dd5e07e76271
+  md5: 2f84852b723ac4389eb188db695526bb
+  depends:
+  - libgcc-ng 14.1.0 he277a41_0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3805250
+  timestamp: 1719547563542
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
   sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
   md5: 66f03896ffbe1a110ffda05c7a856504
   depends:
@@ -4026,13 +3309,7 @@ packages:
   purls: []
   size: 282688
   timestamp: 1711217970425
-- kind: conda
-  name: libtiff
-  version: 4.6.0
-  build: hf980d43_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-hf980d43_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-hf980d43_3.conda
   sha256: 8f578c4e5acf94479b698aea284b2ebfeb32dc3ae99a60c7ef5e07c7003d98cc
   md5: b6f3abf5726ae33094bee238b4eb492f
   depends:
@@ -4049,12 +3326,7 @@ packages:
   purls: []
   size: 316525
   timestamp: 1711218038581
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
@@ -4064,12 +3336,7 @@ packages:
   purls: []
   size: 33601
   timestamp: 1680112270483
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: hb4cce97_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
   sha256: 616277b0c5f7616c2cdf36f6c316ea3f9aa5bb35f2d4476a349ab58b9b91675f
   md5: 000e30b09db0b7c775b21695dff30969
   depends:
@@ -4079,29 +3346,7 @@ packages:
   purls: []
   size: 35720
   timestamp: 1680113474501
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
-  sha256: 10dded60f274e29c573cfacf6e96f5d0fc374ee431250374a44cbd773916ab9d
-  md5: 5fd7ab3e5f382c70607fbac6335e6e19
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - libwebp 1.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 363577
-  timestamp: 1713201785160
-- kind: conda
-  name: libwebp-base
-  version: 1.4.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
   sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
   md5: b26e8aa824079e1be0294e7152ca4559
   depends:
@@ -4113,12 +3358,19 @@ packages:
   purls: []
   size: 438953
   timestamp: 1713199854503
-- kind: conda
-  name: libxcb
-  version: '1.15'
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+  sha256: 10dded60f274e29c573cfacf6e96f5d0fc374ee431250374a44cbd773916ab9d
+  md5: 5fd7ab3e5f382c70607fbac6335e6e19
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 363577
+  timestamp: 1713201785160
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
   sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
   md5: 33277193f5b92bad9fdd230eb700929c
   depends:
@@ -4131,12 +3383,7 @@ packages:
   purls: []
   size: 384238
   timestamp: 1682082368177
-- kind: conda
-  name: libxcb
-  version: '1.16'
-  build: h7935292_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.16-h7935292_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.16-h7935292_0.conda
   sha256: 5e4fec0243dca4af29cce38182b5a1b109a32f064421389f1a44aa883de79a1b
   md5: 93c0136e9cba96657339dfe25fba4da7
   depends:
@@ -4149,28 +3396,7 @@ packages:
   purls: []
   size: 398500
   timestamp: 1693091042711
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: h31becfc_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
-  md5: b4df5d7d4b63579d081fd3a4cf99740e
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 114269
-  timestamp: 1702724369203
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
@@ -4179,13 +3405,16 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
-- kind: conda
-  name: libxml2
-  version: 2.9.14
-  build: h22db469_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.9.14-h22db469_4.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+  sha256: 6b46c397644091b8a26a3048636d10b989b1bf266d4be5e9474bf763f828f41f
+  md5: b4df5d7d4b63579d081fd3a4cf99740e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 114269
+  timestamp: 1702724369203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.9.14-h22db469_4.tar.bz2
   sha256: 3c00e90a6eb6cc741731a09f848c12f3ef5ba5d03c9bbeb194029f39b7a48a5f
   md5: aced7c1f4b4dbfea08e033c6ae97c53e
   depends:
@@ -4199,13 +3428,7 @@ packages:
   purls: []
   size: 789131
   timestamp: 1660339970399
-- kind: conda
-  name: libzlib
-  version: 1.2.13
-  build: h4ab18f5_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
   sha256: 8ced4afed6322172182af503f21725d072a589a6eb918f8a58135c1e00d35980
   md5: 27329162c0dc732bcf67a4e0cd488125
   depends:
@@ -4217,13 +3440,7 @@ packages:
   purls: []
   size: 61571
   timestamp: 1716874066944
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h68df207_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h68df207_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.1-h68df207_1.conda
   sha256: 0d6dfd1e36e10c205ff1fdcf42d42289ff0f50be7a4eaa7b34f086a5e22a0734
   md5: b13fb82f88902e34dd0638cd7d378c21
   depends:
@@ -4235,10 +3452,9 @@ packages:
   purls: []
   size: 67199
   timestamp: 1716874136348
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/03/62/70f5a0c2dd208f9f3f2f9afd103aec42ee4d9ad2401d78342f75e9b8da36/Mako-1.3.5-py3-none-any.whl
   name: mako
   version: 1.3.5
-  url: https://files.pythonhosted.org/packages/03/62/70f5a0c2dd208f9f3f2f9afd103aec42ee4d9ad2401d78342f75e9b8da36/Mako-1.3.5-py3-none-any.whl
   sha256: 260f1dbc3a519453a9c856dedfe4beb4e50bd5a26d96386cb6c80856556bb91a
   requires_dist:
   - markupsafe>=0.9.2
@@ -4246,24 +3462,17 @@ packages:
   - lingua ; extra == 'lingua'
   - pytest ; extra == 'testing'
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: markupsafe
   version: 2.1.5
-  url: https://files.pythonhosted.org/packages/0a/7b/85681ae3c33c385b10ac0f8dd025c30af83c78cec1c37a6aa3b55e67f5ec/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: markupsafe
   version: 2.1.5
-  url: https://files.pythonhosted.org/packages/7c/52/2b1b570f6b8b803cef5ac28fdf78c0da318916c7d2fe9402a84d591b394c/MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f
   requires_python: '>=3.7'
-- kind: conda
-  name: matplotlib-base
-  version: 3.9.1
-  build: py310h0b1de36_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py310h0b1de36_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py310h0b1de36_0.conda
   sha256: 519128c33e6e751a7d77f95b92baed5eb81789a66fbc838bde75e38a4ae2e0d9
   md5: 5341c2c1a7f0a9d196f8070bfa4e16ba
   depends:
@@ -4291,12 +3500,7 @@ packages:
   - pkg:pypi/matplotlib?source=conda-forge-mapping
   size: 6976281
   timestamp: 1720648432575
-- kind: conda
-  name: matplotlib-base
-  version: 3.9.1
-  build: py310hf9f654d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.9.1-py310hf9f654d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.9.1-py310hf9f654d_0.conda
   sha256: 1b11994de1281110fb581284efe45476170ca46d7e8b13c6ef6a25bdcaee76e9
   md5: c870149ef7983e13789ed42199e4f15b
   depends:
@@ -4325,21 +3529,14 @@ packages:
   - pkg:pypi/matplotlib?source=conda-forge-mapping
   size: 6800994
   timestamp: 1720648655192
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
   name: matplotlib-inline
   version: 0.1.7
-  url: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
   sha256: df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca
   requires_dist:
   - traitlets
   requires_python: '>=3.8'
-- kind: conda
-  name: munkres
-  version: 1.1.4
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
   sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
   md5: 2ba8498c1018c1e9c61eb99b973dfe19
   depends:
@@ -4350,13 +3547,7 @@ packages:
   - pkg:pypi/munkres?source=conda-forge-mapping
   size: 12452
   timestamp: 1600387789153
-- kind: conda
-  name: ncbi-vdb
-  version: 3.1.1
-  build: h4ac6f70_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/bioconda/linux-64/ncbi-vdb-3.1.1-h4ac6f70_1.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/linux-64/ncbi-vdb-3.1.1-h4ac6f70_1.tar.bz2
   sha256: 911abe8e6c389d0b283ddae60e135379363eedbc86954e791f9ece653ca5f3e0
   md5: 05705db906896430d0d963de7a3c1698
   depends:
@@ -4366,26 +3557,7 @@ packages:
   purls: []
   size: 11168698
   timestamp: 1720645457419
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: h0425590_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
-  sha256: f8002feaa9e0eb929cd123f1275d8c0b3c6ffb7fd9269b192927009df19dc89e
-  md5: 38362af7bfac0efef69675acee564458
-  depends:
-  - libgcc-ng >=12
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 925099
-  timestamp: 1715194843316
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
   sha256: 4fc3b384f4072b68853a0013ea83bdfd3d66b0126e2238e1d6e1560747aa7586
   md5: fcea371545eda051b6deafb24889fc69
   depends:
@@ -4394,12 +3566,16 @@ packages:
   purls: []
   size: 887465
   timestamp: 1715194722503
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py310hb13e2d6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py310hb13e2d6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
+  sha256: f8002feaa9e0eb929cd123f1275d8c0b3c6ffb7fd9269b192927009df19dc89e
+  md5: 38362af7bfac0efef69675acee564458
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 925099
+  timestamp: 1715194843316
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py310hb13e2d6_0.conda
   sha256: 028fe2ea8e915a0a032b75165f11747770326f3d767e642880540c60a3256425
   md5: 6593de64c935768b6bad3e19b3e978be
   depends:
@@ -4418,12 +3594,7 @@ packages:
   - pkg:pypi/numpy?source=conda-forge-mapping
   size: 7009070
   timestamp: 1707225917496
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py310hcbab775_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py310hcbab775_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py310hcbab775_0.conda
   sha256: 027b2d9a63d074ada499727a3cd1af7c4c28a91ecad19bf84dca5b9b5663eff4
   md5: 2cb108b5220653a4024a029e60cf2c66
   depends:
@@ -4443,10 +3614,9 @@ packages:
   - pkg:pypi/numpy?source=conda-forge-mapping
   size: 6085548
   timestamp: 1707225773389
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/8d/94/9cb35371ac834d56ba2bd8870cdab1be25dc664f3a7387f8057ac091916b/openapi_schema_validator-0.4.4-py3-none-any.whl
   name: openapi-schema-validator
   version: 0.4.4
-  url: https://files.pythonhosted.org/packages/8d/94/9cb35371ac834d56ba2bd8870cdab1be25dc664f3a7387f8057ac091916b/openapi_schema_validator-0.4.4-py3-none-any.whl
   sha256: 79f37f38ef9fd5206b924ed7a6f382cea7b649b3b56383c47f1906082b7b9015
   requires_dist:
   - jsonschema>=4.0.0,<4.18.0
@@ -4454,44 +3624,19 @@ packages:
   - sphinx>=5.3.0,<6.0.0 ; extra == 'docs'
   - sphinx-immaterial>=0.11.0,<0.12.0 ; extra == 'docs'
   requires_python: '>=3.7.0,<4.0.0'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/a8/68/05df6b11a082ee09b8b5319b3c8aeda58b8d3bccf89f201c45e8fe8a91d2/openapi_spec_validator-0.5.7-py3-none-any.whl
   name: openapi-spec-validator
   version: 0.5.7
-  url: https://files.pythonhosted.org/packages/a8/68/05df6b11a082ee09b8b5319b3c8aeda58b8d3bccf89f201c45e8fe8a91d2/openapi_spec_validator-0.5.7-py3-none-any.whl
   sha256: 8712d2879db7692974ef89c47a3ebfc79436442921ec3a826ac0ce80cde8c549
   requires_dist:
-  - importlib-resources>=5.8.0,<6.0.0 ; python_version < '3.9'
+  - importlib-resources>=5.8.0,<6.0.0 ; python_full_version < '3.9'
   - jsonschema>=4.0.0,<4.18.0
   - jsonschema-spec>=0.1.1,<0.2.0
   - lazy-object-proxy>=1.7.1,<2.0.0
   - openapi-schema-validator>=0.4.2,<0.5.0
-  - typing-extensions>=4.5.0,<5.0.0 ; python_version < '3.8'
+  - typing-extensions>=4.5.0,<5.0.0 ; python_full_version < '3.8'
   requires_python: '>=3.7.0,<4.0.0'
-- kind: conda
-  name: openjpeg
-  version: 2.5.2
-  build: h0d9d63b_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.2-h0d9d63b_0.conda
-  sha256: d83375856601bc67c11295b537548a937a6896ede9d0a51d78bf5e921ab07c6f
-  md5: fd2898519e839d5ceb778343f39a3176
-  depends:
-  - libgcc-ng >=12
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  purls: []
-  size: 374964
-  timestamp: 1709159226478
-- kind: conda
-  name: openjpeg
-  version: 2.5.2
-  build: h488ebb8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
   sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
   md5: 7f2e286780f072ed750df46dc2631138
   depends:
@@ -4505,13 +3650,21 @@ packages:
   purls: []
   size: 341592
   timestamp: 1709159244431
-- kind: conda
-  name: openssl
-  version: 3.3.1
-  build: h4bc722e_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.2-h0d9d63b_0.conda
+  sha256: d83375856601bc67c11295b537548a937a6896ede9d0a51d78bf5e921ab07c6f
+  md5: fd2898519e839d5ceb778343f39a3176
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 374964
+  timestamp: 1709159226478
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
   sha256: b294b3cc706ad1048cdb514f0db3da9f37ae3fcc0c53a7104083dd0918adb200
   md5: e1b454497f9f7c1147fdde4b53f1b512
   depends:
@@ -4525,13 +3678,7 @@ packages:
   purls: []
   size: 2895213
   timestamp: 1721194688955
-- kind: conda
-  name: openssl
-  version: 3.3.1
-  build: h68df207_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_2.conda
   sha256: 6c15fd3e6c1dd92b17533fe307cb758be88e85e32e1b988507708905357acb60
   md5: e53f74e640d477466e04bae394b0d163
   depends:
@@ -4544,13 +3691,7 @@ packages:
   purls: []
   size: 3435721
   timestamp: 1721194625490
-- kind: conda
-  name: ossuuid
-  version: 1.6.2
-  build: hf484d3e_1000
-  build_number: 1000
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ossuuid-1.6.2-hf484d3e_1000.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ossuuid-1.6.2-hf484d3e_1000.tar.bz2
   sha256: 9879a6c9be1c54cc6be2e3354ecf81feab7e6947f116baa2c1e3c03dc7343673
   md5: 0ca24876ead80a9290d3936aea5fefb1
   depends:
@@ -4560,13 +3701,7 @@ packages:
   purls: []
   size: 56891
   timestamp: 1535823519264
-- kind: conda
-  name: packaging
-  version: '24.1'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
   sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
   md5: cbe1bb1f21567018ce595d9c2be0f0db
   depends:
@@ -4577,18 +3712,17 @@ packages:
   - pkg:pypi/packaging?source=conda-forge-mapping
   size: 50290
   timestamp: 1718189540074
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/c2/59/cb4234bc9b968c57e81861b306b10cd8170272c57b098b724d3de5eda124/pandas-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: pandas
   version: 2.0.3
-  url: https://files.pythonhosted.org/packages/c2/59/cb4234bc9b968c57e81861b306b10cd8170272c57b098b724d3de5eda124/pandas-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: ce0c6f76a0f1ba361551f3e6dceaff06bde7514a374aa43e33b588ec10420183
   requires_dist:
   - python-dateutil>=2.8.2
   - pytz>=2020.1
   - tzdata>=2022.1
-  - numpy>=1.20.3 ; python_version < '3.10'
-  - numpy>=1.21.0 ; python_version >= '3.10'
-  - numpy>=1.23.2 ; python_version >= '3.11'
+  - numpy>=1.20.3 ; python_full_version < '3.10'
+  - numpy>=1.21.0 ; python_full_version >= '3.10'
+  - numpy>=1.23.2 ; python_full_version >= '3.11'
   - beautifulsoup4>=4.9.3 ; extra == 'all'
   - bottleneck>=1.3.2 ; extra == 'all'
   - brotlipy>=0.7.0 ; extra == 'all'
@@ -4665,18 +3799,17 @@ packages:
   - pytest-asyncio>=0.17.0 ; extra == 'test'
   - lxml>=4.6.3 ; extra == 'xml'
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/e3/59/35a2892bf09ded9c1bf3804461efe772836a5261ef5dfb4e264ce813ff99/pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: pandas
   version: 2.0.3
-  url: https://files.pythonhosted.org/packages/e3/59/35a2892bf09ded9c1bf3804461efe772836a5261ef5dfb4e264ce813ff99/pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: ba619e410a21d8c387a1ea6e8a0e49bb42216474436245718d7f2e88a2f8d7c0
   requires_dist:
   - python-dateutil>=2.8.2
   - pytz>=2020.1
   - tzdata>=2022.1
-  - numpy>=1.20.3 ; python_version < '3.10'
-  - numpy>=1.21.0 ; python_version >= '3.10'
-  - numpy>=1.23.2 ; python_version >= '3.11'
+  - numpy>=1.20.3 ; python_full_version < '3.10'
+  - numpy>=1.21.0 ; python_full_version >= '3.10'
+  - numpy>=1.23.2 ; python_full_version >= '3.11'
   - beautifulsoup4>=4.9.3 ; extra == 'all'
   - bottleneck>=1.3.2 ; extra == 'all'
   - brotlipy>=0.7.0 ; extra == 'all'
@@ -4753,10 +3886,9 @@ packages:
   - pytest-asyncio>=0.17.0 ; extra == 'test'
   - lxml>=4.6.3 ; extra == 'xml'
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
   name: parso
   version: 0.8.4
-  url: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
   sha256: a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18
   requires_dist:
   - flake8==5.0.4 ; extra == 'qa'
@@ -4765,19 +3897,12 @@ packages:
   - docopt ; extra == 'testing'
   - pytest ; extra == 'testing'
   requires_python: '>=3.6'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/5b/0a/acfb251ba01009d3053f04f4661e96abf9d485266b04a0a4deebc702d9cb/pathable-0.4.3-py3-none-any.whl
   name: pathable
   version: 0.4.3
-  url: https://files.pythonhosted.org/packages/5b/0a/acfb251ba01009d3053f04f4661e96abf9d485266b04a0a4deebc702d9cb/pathable-0.4.3-py3-none-any.whl
   sha256: cdd7b1f9d7d5c8b8d3315dbf5a86b2596053ae845f056f57d97c0eefff84da14
   requires_python: '>=3.7.0,<4.0.0'
-- kind: conda
-  name: pep517
-  version: 0.13.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
   sha256: 6a6f2fa6bc9106b2edcccc142242dc3ab1f2f77a6debbd5b480f08482f052636
   md5: d94aa03d99d8adc9898f783eba0d84d2
   depends:
@@ -4789,13 +3914,8 @@ packages:
   - pkg:pypi/pep517?source=conda-forge-mapping
   size: 19044
   timestamp: 1667916747996
-- kind: conda
-  name: perl
-  version: 5.32.1
-  build: 7_hd590300_perl5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
   build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
   sha256: 9ec32b6936b0e37bcb0ed34f22ec3116e75b3c0964f9f50ecea5f58734ed6ce9
   md5: f2cfec9406850991f4e3d960cc9e3321
   depends:
@@ -4805,12 +3925,7 @@ packages:
   purls: []
   size: 13344463
   timestamp: 1703310653947
-- kind: conda
-  name: perl-alien-build
-  version: '2.48'
-  build: pl5321hec16e2b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/bioconda/linux-64/perl-alien-build-2.48-pl5321hec16e2b_0.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/linux-64/perl-alien-build-2.48-pl5321hec16e2b_0.tar.bz2
   sha256: ae4ebedf9b5993d175220f68e2edfdf736e200e8a566c5048a4b039f0e0a96f4
   md5: 8b1ea03a11ce6b27945962c47013f93e
   depends:
@@ -4826,12 +3941,7 @@ packages:
   purls: []
   size: 175739
   timestamp: 1648500923436
-- kind: conda
-  name: perl-alien-libxml2
-  version: '0.17'
-  build: pl5321hec16e2b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/bioconda/linux-64/perl-alien-libxml2-0.17-pl5321hec16e2b_0.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/linux-64/perl-alien-libxml2-0.17-pl5321hec16e2b_0.tar.bz2
   sha256: f14ac664d7d664ab2cad24f5b817a8bc691e34703b5f4ec5f9e80ae663d7cb39
   md5: 4628ba7447031d6e4661732a2e7bdc64
   depends:
@@ -4842,13 +3952,7 @@ packages:
   purls: []
   size: 13021
   timestamp: 1648501301372
-- kind: conda
-  name: perl-business-isbn
-  version: '3.007'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-business-isbn-3.007-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-business-isbn-3.007-pl5321hd8ed1ab_0.tar.bz2
   sha256: fa0b99650ac3bc098d4b34d23eea8f5101f7a5e8c04fc50fac6b8bff70161848
   md5: a7a3d7614e1a73b8d9c20030651d6006
   depends:
@@ -4858,13 +3962,7 @@ packages:
   purls: []
   size: 18309
   timestamp: 1665411030544
-- kind: conda
-  name: perl-business-isbn-data
-  version: '20210112.006'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-business-isbn-data-20210112.006-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-business-isbn-data-20210112.006-pl5321hd8ed1ab_0.tar.bz2
   sha256: 457f7bdea5c7154472a18ab10d7c40144d65793446d9cb40877dc9c37c6b3b59
   md5: a70f08650ec3919ee5e599834f1349d3
   depends:
@@ -4875,13 +3973,7 @@ packages:
   purls: []
   size: 21540
   timestamp: 1660390931370
-- kind: conda
-  name: perl-capture-tiny
-  version: '0.48'
-  build: pl5321ha770c72_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-capture-tiny-0.48-pl5321ha770c72_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-capture-tiny-0.48-pl5321ha770c72_1.tar.bz2
   sha256: 0c0e8e7a342edcdd8638bc2ecf1fca13917b67bcf40890bcff7a7bf4db2ff4d3
   md5: 4859b3d284090166394875e68184dc9c
   depends:
@@ -4890,13 +3982,7 @@ packages:
   purls: []
   size: 16519
   timestamp: 1643301265873
-- kind: conda
-  name: perl-carp
-  version: '1.50'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-carp-1.50-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-carp-1.50-pl5321hd8ed1ab_0.tar.bz2
   sha256: 1981e31113e1e77a2cdc13db657c636f047cd3be2a64d9a0bffac03c5427c1bd
   md5: bdddc03e28019b902da71b722f2288d7
   depends:
@@ -4908,13 +3994,7 @@ packages:
   purls: []
   size: 22257
   timestamp: 1636653208008
-- kind: conda
-  name: perl-constant
-  version: '1.33'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-constant-1.33-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-constant-1.33-pl5321hd8ed1ab_0.tar.bz2
   sha256: cfd5ef9af8de221292f7059d1ff88ff10f1340fc4dbbd0dc81ce2275bf76651d
   md5: 7f9fc9cfa08a3fe36ffcff820c65c3ac
   depends:
@@ -4924,13 +4004,7 @@ packages:
   purls: []
   size: 15711
   timestamp: 1636645107290
-- kind: conda
-  name: perl-exporter
-  version: '5.74'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-exporter-5.74-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-exporter-5.74-pl5321hd8ed1ab_0.tar.bz2
   sha256: 42271d0b79043a10a89044acb5febea50046b745dd2fc37e02943bc3bc75bf8e
   md5: fd2eac4e35f8c970870a3961c1df3e29
   depends:
@@ -4940,13 +4014,7 @@ packages:
   purls: []
   size: 19071
   timestamp: 1636696009075
-- kind: conda
-  name: perl-extutils-makemaker
-  version: '7.70'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-extutils-makemaker-7.70-pl5321hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-extutils-makemaker-7.70-pl5321hd8ed1ab_0.conda
   sha256: 1d3f342ca74cf2948c3edcfe0d3367b1db0fc64bb163393a2e025336dec3a40c
   md5: ec3e57ed34f7765bfc7054a05868ce5d
   depends:
@@ -4956,13 +4024,7 @@ packages:
   purls: []
   size: 157323
   timestamp: 1679847836884
-- kind: conda
-  name: perl-ffi-checklib
-  version: '0.28'
-  build: pl5321hdfd78af_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/bioconda/noarch/perl-ffi-checklib-0.28-pl5321hdfd78af_0.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/noarch/perl-ffi-checklib-0.28-pl5321hdfd78af_0.tar.bz2
   sha256: 4ac8de71ec66b6f13785f134be7878507f0003844e279be6290b7dc72cc2aa88
   md5: 05451eeb5e82ccf46831248c55c6218a
   depends:
@@ -4971,13 +4033,7 @@ packages:
   purls: []
   size: 16150
   timestamp: 1648502850959
-- kind: conda
-  name: perl-file-chdir
-  version: '0.1011'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-file-chdir-0.1011-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-file-chdir-0.1011-pl5321hd8ed1ab_0.tar.bz2
   sha256: 736b5c79e0ea19efb8f97f628a508cf42a1d5b6bc5533df1bd454651e28950c2
   md5: c057570093f9298e9c5e4391877f2301
   depends:
@@ -4988,13 +4044,7 @@ packages:
   purls: []
   size: 16973
   timestamp: 1660380425665
-- kind: conda
-  name: perl-file-path
-  version: '2.18'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-file-path-2.18-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-file-path-2.18-pl5321hd8ed1ab_0.tar.bz2
   sha256: ac7a0e0c36ec199709c8523132ded35efb84941a1a476b271fd25362dfbf5339
   md5: e13e456f61b8261ba074c0aa93086afe
   depends:
@@ -5005,13 +4055,7 @@ packages:
   purls: []
   size: 22382
   timestamp: 1636696260633
-- kind: conda
-  name: perl-file-temp
-  version: '0.2304'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-file-temp-0.2304-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-file-temp-0.2304-pl5321hd8ed1ab_0.tar.bz2
   sha256: 91f9fe152b38441386053876198d0c9437e7b4b5fa7da1e5db48b9e1b21fdae9
   md5: 0a039c4fc36748942287ee10d0431515
   depends:
@@ -5026,13 +4070,7 @@ packages:
   purls: []
   size: 31509
   timestamp: 1636696164992
-- kind: conda
-  name: perl-file-which
-  version: '1.24'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-file-which-1.24-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-file-which-1.24-pl5321hd8ed1ab_0.tar.bz2
   sha256: 901e9c4177b6bdb23600446fd64a105a437112e63bc23a6163f669bc5098c502
   md5: 94e5b2c9d56ef7c4c70ddf51ac38ae3d
   depends:
@@ -5042,13 +4080,7 @@ packages:
   purls: []
   size: 17329
   timestamp: 1636695979827
-- kind: conda
-  name: perl-importer
-  version: '0.026'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-importer-0.026-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-importer-0.026-pl5321hd8ed1ab_0.tar.bz2
   sha256: f40d5302de8c81282b5216edd8c65aecc551ef725db3351c208bff9b077e66a2
   md5: 66e17c342d13c39a12c1059f13f9b72c
   depends:
@@ -5058,13 +4090,7 @@ packages:
   purls: []
   size: 26921
   timestamp: 1660471365476
-- kind: conda
-  name: perl-parent
-  version: '0.241'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-parent-0.241-pl5321hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-parent-0.241-pl5321hd8ed1ab_0.conda
   sha256: b52087c6e22eb9e53454f86d55275534400e6252e190ee262b062c587546aa7b
   md5: 44ab631ed23c25c224ed4c849d713aac
   depends:
@@ -5074,13 +4100,7 @@ packages:
   purls: []
   size: 13660
   timestamp: 1676442077146
-- kind: conda
-  name: perl-path-tiny
-  version: '0.124'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-path-tiny-0.124-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-path-tiny-0.124-pl5321hd8ed1ab_0.tar.bz2
   sha256: 03b980520f6bcf7612fdee607e571ff91660d8fbfeb57ae9350921c5a38459d1
   md5: 456a8757a2e5272fb1dcb6435e037f3a
   depends:
@@ -5090,12 +4110,7 @@ packages:
   purls: []
   size: 41525
   timestamp: 1662587359913
-- kind: conda
-  name: perl-pathtools
-  version: '3.75'
-  build: pl5321h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-pathtools-3.75-pl5321h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-pathtools-3.75-pl5321h166bdaf_0.tar.bz2
   sha256: 74012776f608545a0d3e10b85c5b2f0a1efd98ff23d0a41e6f4f587524e2da5c
   md5: 4e72abd06ec15cb28c14798dab2c10c8
   depends:
@@ -5107,13 +4122,7 @@ packages:
   purls: []
   size: 49806
   timestamp: 1660296861330
-- kind: conda
-  name: perl-scope-guard
-  version: '0.21'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-scope-guard-0.21-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-scope-guard-0.21-pl5321hd8ed1ab_0.tar.bz2
   sha256: f0cd98e792fe43fcef81af1848f0d985a87b953043f1f6551d2ffdf15daca62c
   md5: daea4e61dfdf06fef9a51dce492508f4
   depends:
@@ -5123,13 +4132,7 @@ packages:
   purls: []
   size: 16123
   timestamp: 1660472428828
-- kind: conda
-  name: perl-sub-info
-  version: '0.002'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-sub-info-0.002-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-sub-info-0.002-pl5321hd8ed1ab_0.tar.bz2
   sha256: 0485649e2aaccdbe46b64d35e07d13f885d28f438f41bee54ecd7e9a9d94d472
   md5: 5b48dcf7df9e4e01d45de2c1f494d830
   depends:
@@ -5141,13 +4144,7 @@ packages:
   purls: []
   size: 19020
   timestamp: 1663840434982
-- kind: conda
-  name: perl-term-table
-  version: '0.016'
-  build: pl5321hdfd78af_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/bioconda/noarch/perl-term-table-0.016-pl5321hdfd78af_0.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/noarch/perl-term-table-0.016-pl5321hdfd78af_0.tar.bz2
   sha256: b3fedb65372e4eabbc5870f22f6b9a6388759fcdeeba9f90a68b33a453170862
   md5: 91a4c19686c0e1c8b34325664bd3eee4
   depends:
@@ -5158,12 +4155,7 @@ packages:
   purls: []
   size: 23576
   timestamp: 1644514107092
-- kind: conda
-  name: perl-test-fatal
-  version: '0.016'
-  build: pl5321ha770c72_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-test-fatal-0.016-pl5321ha770c72_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-test-fatal-0.016-pl5321ha770c72_0.tar.bz2
   sha256: d5420f90b3bca641cdad0c5674b356a060bf1587e82d3828f382a466bdaba6d1
   md5: 5c397b1fd3095004f4ff149af1c0dd3c
   depends:
@@ -5173,12 +4165,7 @@ packages:
   purls: []
   size: 19528
   timestamp: 1666339958976
-- kind: conda
-  name: perl-test-warnings
-  version: '0.031'
-  build: pl5321ha770c72_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-test-warnings-0.031-pl5321ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-test-warnings-0.031-pl5321ha770c72_0.conda
   sha256: 2aaea17941fd456bfe44d15e3f3651d7f27be0cb31235d88e48b71ae857d7ef1
   md5: db0eb51272ea7af7213afaaf7e9967c3
   depends:
@@ -5187,13 +4174,7 @@ packages:
   purls: []
   size: 21724
   timestamp: 1669240328383
-- kind: conda
-  name: perl-test2-suite
-  version: '0.000145'
-  build: pl5321hdfd78af_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/bioconda/noarch/perl-test2-suite-0.000145-pl5321hdfd78af_0.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/noarch/perl-test2-suite-0.000145-pl5321hdfd78af_0.tar.bz2
   sha256: 8bffe19a7fbd8704bd2e1ff6bcc34bf850d6f1b5bbaf72ae948fa881b2b2b1fa
   md5: c07db9debdb82d45be8a2115f5eb952d
   depends:
@@ -5206,12 +4187,7 @@ packages:
   purls: []
   size: 199691
   timestamp: 1646739059274
-- kind: conda
-  name: perl-try-tiny
-  version: '0.31'
-  build: pl5321ha770c72_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-try-tiny-0.31-pl5321ha770c72_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-try-tiny-0.31-pl5321ha770c72_0.tar.bz2
   sha256: 7e74c95eb085b095a258a22ee2f30192d79f23a58cbbcb8ca2b14f4fe0a8c406
   md5: cc23b14ed56bf51d84832d98ebd156af
   depends:
@@ -5221,12 +4197,7 @@ packages:
   purls: []
   size: 17704
   timestamp: 1659695570098
-- kind: conda
-  name: perl-uri
-  version: '5.17'
-  build: pl5321ha770c72_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-uri-5.17-pl5321ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-uri-5.17-pl5321ha770c72_0.conda
   sha256: bc720b225716023dde7d9df01b1f7bd611a94cc64a71879adc40f4be521ec1d9
   md5: 847c007d5f4a59b356a9cd577010b89c
   depends:
@@ -5238,12 +4209,7 @@ packages:
   purls: []
   size: 67685
   timestamp: 1684789768878
-- kind: conda
-  name: perl-xml-libxml
-  version: '2.0207'
-  build: pl5321h661654b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/bioconda/linux-64/perl-xml-libxml-2.0207-pl5321h661654b_0.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/linux-64/perl-xml-libxml-2.0207-pl5321h661654b_0.tar.bz2
   sha256: 089cb685d7badb14991ce85580238131fef84ac64e15a74f026c11259dd93427
   md5: 1ce8ba66c656dbe547110201b1456797
   depends:
@@ -5260,13 +4226,7 @@ packages:
   purls: []
   size: 258537
   timestamp: 1648501774485
-- kind: conda
-  name: perl-xml-namespacesupport
-  version: '1.12'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-xml-namespacesupport-1.12-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-xml-namespacesupport-1.12-pl5321hd8ed1ab_0.tar.bz2
   sha256: bf384bea1057085fdf8daac6e67a96ca892f2fedf4ce0327f9bda5d3a9bce102
   md5: f4ce684ba66b3228bfffb09892235930
   depends:
@@ -5277,13 +4237,7 @@ packages:
   purls: []
   size: 22890
   timestamp: 1664723687849
-- kind: conda
-  name: perl-xml-sax
-  version: '1.02'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-xml-sax-1.02-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-xml-sax-1.02-pl5321hd8ed1ab_0.tar.bz2
   sha256: 324ca36bdfff272c8ac06befcd9d1e9e1b22c1c6449bb3801d7e8b9c92acc6b6
   md5: 3e3fac6ffef3fcda271b5511aecacaa8
   depends:
@@ -5296,13 +4250,7 @@ packages:
   purls: []
   size: 43526
   timestamp: 1664728646828
-- kind: conda
-  name: perl-xml-sax-base
-  version: '1.09'
-  build: pl5321hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/perl-xml-sax-base-1.09-pl5321hd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/perl-xml-sax-base-1.09-pl5321hd8ed1ab_0.tar.bz2
   sha256: e652410a4d02bde1a1d7e0021ee84006113785676267c1e33642ba3d2ea9c254
   md5: a4d9b02cd61c478c9cb58064307a1414
   depends:
@@ -5312,19 +4260,13 @@ packages:
   purls: []
   size: 27575
   timestamp: 1664556675309
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
   name: pexpect
   version: 4.9.0
-  url: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
   sha256: 7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523
   requires_dist:
   - ptyprocess>=0.5
-- kind: conda
-  name: pillow
-  version: 10.3.0
-  build: py310hf73ecf8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py310hf73ecf8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py310hf73ecf8_0.conda
   sha256: 89caf2bb9b6d6d0c874590128b36676615750b5ef121fab514bc737dc48534da
   md5: 1de56cf017dfd02aa84093206a0141a8
   depends:
@@ -5345,12 +4287,7 @@ packages:
   - pkg:pypi/pillow?source=conda-forge-mapping
   size: 41783273
   timestamp: 1712154626576
-- kind: conda
-  name: pillow
-  version: 10.4.0
-  build: py310h611336f_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-10.4.0-py310h611336f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-10.4.0-py310h611336f_0.conda
   sha256: 3ba3199923de8d405a23a9159a0fc1d62ba5dbb4858126dcf41118018d7e4f62
   md5: 5dba9481589d5bd09bd359dbd8478e16
   depends:
@@ -5371,13 +4308,7 @@ packages:
   - pkg:pypi/pillow?source=conda-forge-mapping
   size: 41601464
   timestamp: 1719905871875
-- kind: conda
-  name: pip
-  version: '24.0'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
   sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
   md5: f586ac1e56c8638b64f9c8122a7b8a67
   depends:
@@ -5390,13 +4321,7 @@ packages:
   - pkg:pypi/pip?source=conda-forge-mapping
   size: 1398245
   timestamp: 1706960660581
-- kind: conda
-  name: pluggy
-  version: 1.5.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
   sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
   md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
   depends:
@@ -5407,13 +4332,7 @@ packages:
   - pkg:pypi/pluggy?source=conda-forge-mapping
   size: 23815
   timestamp: 1713667175451
-- kind: conda
-  name: prompt-toolkit
-  version: 3.0.38
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
   sha256: 78c2f3c6195ec350d7d6e5fa3e43274ca8191c181c97a867e2920faaeec0e9bc
   md5: 59ba1bf8ea558751a0d391249a248765
   depends:
@@ -5427,13 +4346,7 @@ packages:
   - pkg:pypi/prompt-toolkit?source=conda-forge-mapping
   size: 269375
   timestamp: 1677601102637
-- kind: conda
-  name: prompt_toolkit
-  version: 3.0.38
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
   sha256: c0f24a75d27918eb33f86902aa6024783d128a89eb3a169bcb22f24163a422b3
   md5: 45b74f64d8808eda7e6f6e6b1d641fd2
   depends:
@@ -5444,12 +4357,7 @@ packages:
   - pkg:pypi/prompt-toolkit?source=conda-forge-mapping
   size: 6402
   timestamp: 1677601110741
-- kind: conda
-  name: psycopg2
-  version: 2.9.9
-  build: py310h275853b_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.9-py310h275853b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.9-py310h275853b_0.conda
   sha256: 583aa8fef12988a26e24a94f7a3b3045412dce3860884b47e28318196cccab70
   md5: ab5ef89b98dad51f23d49a44f114905f
   depends:
@@ -5463,12 +4371,7 @@ packages:
   - pkg:pypi/psycopg2?source=conda-forge-mapping
   size: 173407
   timestamp: 1701737645253
-- kind: conda
-  name: psycopg2
-  version: 2.9.9
-  build: py310h729f94d_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/psycopg2-2.9.9-py310h729f94d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psycopg2-2.9.9-py310h729f94d_0.conda
   sha256: a6c49dd6ce5dc74ad5c44a9a4f8d68113e770acc68da5b4bb52ee9cc87b871f0
   md5: 6f0e83eaa673cb29ce162578d50df9c1
   depends:
@@ -5482,13 +4385,7 @@ packages:
   - pkg:pypi/psycopg2?source=conda-forge-mapping
   size: 174939
   timestamp: 1701739657914
-- kind: conda
-  name: psycopg2-binary
-  version: 2.9.9
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/psycopg2-binary-2.9.9-pyhd8ed1ab_0.conda
   sha256: bb6184a3de8a6fddaed9104539ada9ac7c5e2bd900284ccf96ef5e4e285e75db
   md5: c15b2ec0570f8988819eea58286dbc19
   depends:
@@ -5500,13 +4397,7 @@ packages:
   - pkg:pypi/psycopg2-binary?source=conda-forge-mapping
   size: 9736
   timestamp: 1701737721752
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: h36c2ea0_1001
-  build_number: 1001
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
   sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
   md5: 22dad4df6e8630e8dff2428f6f6a7036
   depends:
@@ -5516,13 +4407,7 @@ packages:
   purls: []
   size: 5625
   timestamp: 1606147468727
-- kind: conda
-  name: pthread-stubs
-  version: '0.4'
-  build: hb9de7d4_1001
-  build_number: 1001
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
   sha256: f1d7ff5e06cc515ec82010537813c796369f8e9dde46ce3f4fa1a9f70bc7db7d
   md5: d0183ec6ce0b5aaa3486df25fa5f0ded
   depends:
@@ -5532,25 +4417,17 @@ packages:
   purls: []
   size: 5657
   timestamp: 1606147738742
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
   name: ptyprocess
   version: 0.7.0
-  url: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
   sha256: 4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
   name: pure-eval
   version: 0.2.3
-  url: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
   sha256: 1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0
   requires_dist:
   - pytest ; extra == 'tests'
-- kind: conda
-  name: pycparser
-  version: '2.22'
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   md5: 844d9eb3b43095b031874477f7d70088
   depends:
@@ -5561,13 +4438,22 @@ packages:
   - pkg:pypi/pycparser?source=conda-forge-mapping
   size: 105098
   timestamp: 1711811634025
-- kind: conda
-  name: pycurl
-  version: 7.45.3
-  build: py310h00deb75_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pycurl-7.45.3-py310h00deb75_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pycurl-7.45.3-py310h80730c7_1.conda
+  sha256: ceed836d36d1fb47040106bcd4f4a76799cf42320646091f8169022a6a56d0ed
+  md5: 95c2dcd0c261c39f492ac10a50460d95
+  depends:
+  - libcurl >=8.5.0,<9.0a0
+  - libgcc-ng >=12
+  - openssl >=3.2.1,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: LGPL, MIT
+  license_family: LGPL
+  purls:
+  - pkg:pypi/pycurl?source=conda-forge-mapping
+  size: 78127
+  timestamp: 1710066957723
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pycurl-7.45.3-py310h00deb75_1.conda
   sha256: 4f582ca5e5cbb0dcd46c2a7a9be8848f403a3badc62f0733fa2897ba96544cfe
   md5: 5911b0245c94cbc65be928e5552c9e9c
   depends:
@@ -5583,42 +4469,14 @@ packages:
   - pkg:pypi/pycurl?source=conda-forge-mapping
   size: 80804
   timestamp: 1710067015470
-- kind: conda
-  name: pycurl
-  version: 7.45.3
-  build: py310h80730c7_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pycurl-7.45.3-py310h80730c7_1.conda
-  sha256: ceed836d36d1fb47040106bcd4f4a76799cf42320646091f8169022a6a56d0ed
-  md5: 95c2dcd0c261c39f492ac10a50460d95
-  depends:
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: LGPL, MIT
-  license_family: LGPL
-  purls:
-  - pkg:pypi/pycurl?source=conda-forge-mapping
-  size: 78127
-  timestamp: 1710066957723
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
   name: pygments
   version: 2.18.0
-  url: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
   sha256: b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
   requires_python: '>=3.8'
-- kind: conda
-  name: pyopenssl
-  version: 23.1.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.1.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.1.1-pyhd8ed1ab_0.conda
   sha256: 458428cb867f70f2af2a4ed59d382291ea3eb3f10490196070a15d1d71d5432a
   md5: 0b34aa3ab7e7ccb1765a03dd9ed29938
   depends:
@@ -5630,13 +4488,7 @@ packages:
   - pkg:pypi/pyopenssl?source=conda-forge-mapping
   size: 128079
   timestamp: 1680037561734
-- kind: conda
-  name: pyparsing
-  version: 3.1.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
   sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
   md5: b9a4dacf97241704529131a0dfc0494f
   depends:
@@ -5647,26 +4499,17 @@ packages:
   - pkg:pypi/pyparsing?source=conda-forge-mapping
   size: 89455
   timestamp: 1709721146886
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/9f/4f/8342079ea331031ef9ed57edd312a9ad283bcc8adfaf268931ae356a09a6/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: pyrsistent
   version: 0.20.0
-  url: https://files.pythonhosted.org/packages/9f/4f/8342079ea331031ef9ed57edd312a9ad283bcc8adfaf268931ae356a09a6/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: c1beb78af5423b879edaf23c5591ff292cf7c33979734c99aa66d5914ead880f
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/d7/b7/64a125c488243965b7c5118352e47c6f89df95b4ac306d31cee409153d57/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: pyrsistent
   version: 0.20.0
-  url: https://files.pythonhosted.org/packages/d7/b7/64a125c488243965b7c5118352e47c6f89df95b4ac306d31cee409153d57/pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 21cc459636983764e692b9eba7144cdd54fdec23ccdb1e8ba392a63666c60c34
   requires_python: '>=3.8'
-- kind: conda
-  name: pysocks
-  version: 1.7.1
-  build: pyha2e5f31_6
-  build_number: 6
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
   sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
   md5: 2a7de29fb590ca14b5243c4c812c8025
   depends:
@@ -5678,13 +4521,7 @@ packages:
   - pkg:pypi/pysocks?source=conda-forge-mapping
   size: 18981
   timestamp: 1661604969727
-- kind: conda
-  name: pytest
-  version: 8.3.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
   sha256: 72c84a3cd9fe82835a88e975fd2a0dbf2071d1c423ea4f79e7930578c1014873
   md5: e010a224b90f1f623a917c35addbb924
   depends:
@@ -5702,13 +4539,7 @@ packages:
   - pkg:pypi/pytest?source=conda-forge-mapping
   size: 257671
   timestamp: 1721923749407
-- kind: conda
-  name: pytest-cov
-  version: 5.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
   sha256: 218306243faf3c36347131c2b36bb189daa948ac2e92c7ab52bb26cc8c157b3c
   md5: c54c0107057d67ddf077751339ec2c63
   depends:
@@ -5722,42 +4553,7 @@ packages:
   - pkg:pypi/pytest-cov?source=conda-forge-mapping
   size: 25507
   timestamp: 1711411153367
-- kind: conda
-  name: python
-  version: 3.10.14
-  build: hbbe8eec_0_cpython
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.10.14-hbbe8eec_0_cpython.conda
-  sha256: 992583064b95d256e1b1f03581a51e225a425894d865e35ea2bf3017444c3e84
-  md5: 8a8ee3a8c62032c554debc785a3b5aba
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-aarch64 >=2.36.1
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.10.* *_cp310
-  license: Python-2.0
-  purls: []
-  size: 13116477
-  timestamp: 1710971217224
-- kind: conda
-  name: python
-  version: 3.10.14
-  build: hd12c33a_0_cpython
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.14-hd12c33a_0_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.14-hd12c33a_0_cpython.conda
   sha256: 76a5d12e73542678b70a94570f7b0f7763f9a938f77f0e75d9ea615ef22aa84c
   md5: 2b4ba962994e8bd4be9ff5b64b75aff2
   depends:
@@ -5782,13 +4578,32 @@ packages:
   purls: []
   size: 25517742
   timestamp: 1710939725109
-- kind: conda
-  name: python-dateutil
-  version: 2.9.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.10.14-hbbe8eec_0_cpython.conda
+  sha256: 992583064b95d256e1b1f03581a51e225a425894d865e35ea2bf3017444c3e84
+  md5: 8a8ee3a8c62032c554debc785a3b5aba
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-aarch64 >=2.36.1
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.45.2,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  purls: []
+  size: 13116477
+  timestamp: 1710971217224
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   md5: 2cf4264fffb9e6eff6031c5b6884d61c
   depends:
@@ -5800,13 +4615,8 @@ packages:
   - pkg:pypi/python-dateutil?source=conda-forge-mapping
   size: 222742
   timestamp: 1709299922152
-- kind: conda
-  name: python_abi
-  version: '3.10'
-  build: 4_cp310
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
   build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
   sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
   md5: 26322ec5d7712c3ded99dd656142b8ce
   constrains:
@@ -5816,13 +4626,8 @@ packages:
   purls: []
   size: 6398
   timestamp: 1695147363189
-- kind: conda
-  name: python_abi
-  version: '3.10'
-  build: 4_cp310
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.10-4_cp310.conda
   build_number: 4
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.10-4_cp310.conda
   sha256: 9191cc3ddf380b655c08b3436a8174ce0cc798a6dfcfa8ee80fa793d0b7165de
   md5: b0ff2ed109650f9e90d627d3119eb442
   constrains:
@@ -5832,30 +4637,21 @@ packages:
   purls: []
   size: 6436
   timestamp: 1695147402616
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl
   name: pytz
   version: '2024.1'
-  url: https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl
   sha256: 328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: pyyaml
   version: 6.0.1
-  url: https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515
   requires_python: '>=3.6'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f1/26/55e4f21db1f72eaef092015d9017c11510e7e6301c62a6cfee91295d13c6/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: pyyaml
   version: 6.0.1
-  url: https://files.pythonhosted.org/packages/f1/26/55e4f21db1f72eaef092015d9017c11510e7e6301c62a6cfee91295d13c6/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: 69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938
   requires_python: '>=3.6'
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: h434a139_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
   sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   md5: 353823361b1d27eb3960efb076dfcaf6
   depends:
@@ -5866,13 +4662,7 @@ packages:
   purls: []
   size: 552937
   timestamp: 1720813982144
-- kind: conda
-  name: qhull
-  version: '2020.2'
-  build: h70be974_5
-  build_number: 5
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qhull-2020.2-h70be974_5.conda
   sha256: 49f777bdf3c5e030a8c7b24c58cdfe9486b51d6ae0001841079a3228bdf9fb51
   md5: bb138086d938e2b64f5f364945793ebf
   depends:
@@ -5882,13 +4672,7 @@ packages:
   purls: []
   size: 554571
   timestamp: 1720813941183
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8228510_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   md5: 47d31b792659ce70f470b5c82fdfb7a4
   depends:
@@ -5899,13 +4683,7 @@ packages:
   purls: []
   size: 281456
   timestamp: 1679532220005
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8fc344f_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
   sha256: 4c99f7417419734e3797d45bc355e61c26520e111893b0d7087a01a7fbfbe3dd
   md5: 105eb1e16bf83bfb2eb380a48032b655
   depends:
@@ -5916,48 +4694,39 @@ packages:
   purls: []
   size: 294092
   timestamp: 1679532238805
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/e0/7f/21a09f8c9f5db6f5e24432f7a0f916ca386025d74e4da6d0f5164aa9a78a/redis-4.5.5-py3-none-any.whl
   name: redis
   version: 4.5.5
-  url: https://files.pythonhosted.org/packages/e0/7f/21a09f8c9f5db6f5e24432f7a0f916ca386025d74e4da6d0f5164aa9a78a/redis-4.5.5-py3-none-any.whl
   sha256: 77929bc7f5dab9adf3acba2d3bb7d7658f1e0c2f1cafe7eb36434e751c471119
   requires_dist:
   - async-timeout>=4.0.2 ; python_full_version <= '3.11.2'
-  - importlib-metadata>=1.0 ; python_version < '3.8'
-  - typing-extensions ; python_version < '3.8'
+  - importlib-metadata>=1.0 ; python_full_version < '3.8'
+  - typing-extensions ; python_full_version < '3.8'
   - hiredis>=1.0.0 ; extra == 'hiredis'
   - cryptography>=36.0.1 ; extra == 'ocsp'
   - pyopenssl==20.0.1 ; extra == 'ocsp'
   - requests>=2.26.0 ; extra == 'ocsp'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
   name: requests
   version: 2.32.3
-  url: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
   sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
   requires_dist:
-  - charset-normalizer<4,>=2
-  - idna<4,>=2.5
-  - urllib3<3,>=1.21.1
+  - charset-normalizer>=2,<4
+  - idna>=2.5,<4
+  - urllib3>=1.21.1,<3
   - certifi>=2017.4.17
-  - pysocks!=1.5.7,>=1.5.6 ; extra == 'socks'
-  - chardet<6,>=3.0.2 ; extra == 'use-chardet-on-py3'
+  - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
+  - chardet>=3.0.2,<6 ; extra == 'use-chardet-on-py3'
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
   name: rfc3339-validator
   version: 0.1.4
-  url: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
   sha256: 24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
   requires_dist:
   - six
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
-- kind: conda
-  name: ruamel.yaml
-  version: 0.17.21
-  build: py310h1fa729e_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.21-py310h1fa729e_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.21-py310h1fa729e_3.conda
   sha256: 2e390037976718f762b8db6703aadeb950fe4c409c64a7e5985157cbb2d58d52
   md5: 97204ae92b703d74a983db0e6d07d009
   depends:
@@ -5972,13 +4741,7 @@ packages:
   - pkg:pypi/ruamel-yaml?source=conda-forge-mapping
   size: 189698
   timestamp: 1678273107767
-- kind: conda
-  name: ruamel.yaml
-  version: 0.17.21
-  build: py310hb89b984_3
-  build_number: 3
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.17.21-py310hb89b984_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml-0.17.21-py310hb89b984_3.conda
   sha256: a0dd5f23422a1ea05c03598e991f3f811de5197ff70ff3f301f415510df9340c
   md5: 3c88178b698c68cdacf6f4703f57516d
   depends:
@@ -5994,13 +4757,7 @@ packages:
   - pkg:pypi/ruamel-yaml?source=conda-forge-mapping
   size: 191172
   timestamp: 1678273210681
-- kind: conda
-  name: ruamel.yaml.clib
-  version: 0.2.7
-  build: py310h2372a71_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.7-py310h2372a71_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.7-py310h2372a71_2.conda
   sha256: 00c76baad0a896f6f259093ec5328ac06cf422e6528745b28ee7e5057f54668f
   md5: 7c9da9721ee545d57ad759f020172853
   depends:
@@ -6013,13 +4770,7 @@ packages:
   - pkg:pypi/ruamel-yaml-clib?source=conda-forge-mapping
   size: 134875
   timestamp: 1695997043171
-- kind: conda
-  name: ruamel.yaml.clib
-  version: 0.2.7
-  build: py310hb299538_2
-  build_number: 2
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.7-py310hb299538_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.7-py310hb299538_2.conda
   sha256: 7e05bebd42bfec0bd063f1dc4eb9a3cbf06fcbbcb2bcc4f0378d0e40e8834336
   md5: 45eee1c3a48b16bad62fd180427c556c
   depends:
@@ -6033,12 +4784,7 @@ packages:
   - pkg:pypi/ruamel-yaml-clib?source=conda-forge-mapping
   size: 127907
   timestamp: 1695997049187
-- kind: conda
-  name: s2n
-  version: 1.4.0
-  build: h06160fa_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.0-h06160fa_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.0-h06160fa_0.conda
   sha256: f6cc2bdcb5d809bbaae218e03bdefef4a309d1fc7ccc9444fda59bd4553a83f8
   md5: 3d1b58d2664d96f9fbc0afe5e1d04632
   depends:
@@ -6049,12 +4795,7 @@ packages:
   purls: []
   size: 329669
   timestamp: 1701891861649
-- kind: conda
-  name: s2n
-  version: 1.4.0
-  build: h5a25046_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.4.0-h5a25046_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.4.0-h5a25046_0.conda
   sha256: 56263f7c56b100d7ed2cc0b8e32987d040eb277881cfeac5c04b2ecf4a18e5b4
   md5: 59c83693b08b1e8738742751493419f9
   depends:
@@ -6065,22 +4806,36 @@ packages:
   purls: []
   size: 325373
   timestamp: 1701891919216
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/d9/17/a3b666f5ef9543cfd3c661d39d1e193abb9649d0cfbbfee3cf3b51d5af02/s3transfer-0.6.2-py3-none-any.whl
   name: s3transfer
   version: 0.6.2
-  url: https://files.pythonhosted.org/packages/d9/17/a3b666f5ef9543cfd3c661d39d1e193abb9649d0cfbbfee3cf3b51d5af02/s3transfer-0.6.2-py3-none-any.whl
   sha256: b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084
   requires_dist:
-  - botocore<2.0a0,>=1.12.36
-  - botocore[crt]<2.0a0,>=1.20.29 ; extra == 'crt'
+  - botocore>=1.12.36,<2.0a0
+  - botocore[crt]>=1.20.29,<2.0a0 ; extra == 'crt'
   requires_python: '>=3.7'
-- kind: conda
-  name: scipy
-  version: 1.14.0
-  build: py310h70fbbe5_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.14.0-py310h70fbbe5_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py310h93e2701_1.conda
+  sha256: 6752b190d2bc4805a17ffa92eb62743404736e4197b079f0db7d7e1d508d138e
+  md5: c6b2a8134aa49940afe552f69bdef957
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=conda-forge-mapping
+  size: 16749437
+  timestamp: 1720324339175
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/scipy-1.14.0-py310h70fbbe5_1.conda
   sha256: 1ba841de3226bfa52d172368cfef6ee252517f40878e68d374c4efc8bc9baf73
   md5: 503ad5a34b343d1e78aeebe491155749
   depends:
@@ -6102,40 +4857,7 @@ packages:
   - pkg:pypi/scipy?source=conda-forge-mapping
   size: 16897876
   timestamp: 1720324265609
-- kind: conda
-  name: scipy
-  version: 1.14.0
-  build: py310h93e2701_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py310h93e2701_1.conda
-  sha256: 6752b190d2bc4805a17ffa92eb62743404736e4197b079f0db7d7e1d508d138e
-  md5: c6b2a8134aa49940afe552f69bdef957
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/scipy?source=conda-forge-mapping
-  size: 16749437
-  timestamp: 1720324339175
-- kind: conda
-  name: screed
-  version: 1.1.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/screed-1.1.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/screed-1.1.3-pyhd8ed1ab_0.conda
   sha256: b727ded3d0a45c600177db915bf27c7d2fa814d97abb947d6a81fc2e9bce04a5
   md5: c82df785d03d9fe27b316279d333eaec
   depends:
@@ -6147,10 +4869,9 @@ packages:
   - pkg:pypi/screed?source=conda-forge-mapping
   size: 88152
   timestamp: 1701974410494
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/4f/9e/9298785949269c8930e1fd3707b960da6e1a95a2442b747b8f8cca4578cb/sentry_sdk-2.10.0-py2.py3-none-any.whl
   name: sentry-sdk
   version: 2.10.0
-  url: https://files.pythonhosted.org/packages/4f/9e/9298785949269c8930e1fd3707b960da6e1a95a2442b747b8f8cca4578cb/sentry_sdk-2.10.0-py2.py3-none-any.whl
   sha256: 87b3d413c87d8e7f816cc9334bff255a83d8b577db2b22042651c30c19c09190
   requires_dist:
   - urllib3>=1.26.11
@@ -6242,13 +4963,7 @@ packages:
   - starlite>=1.48 ; extra == 'starlite'
   - tornado>=6 ; extra == 'tornado'
   requires_python: '>=3.6'
-- kind: conda
-  name: setuptools
-  version: 71.0.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
   sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
   md5: ee78ac9c720d0d02fcfd420866b82ab1
   depends:
@@ -6259,13 +4974,7 @@ packages:
   - pkg:pypi/setuptools?source=conda-forge-mapping
   size: 1463254
   timestamp: 1721475299854
-- kind: conda
-  name: six
-  version: 1.16.0
-  build: pyh6c4a22f_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
   sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
   md5: e5f25f8dbc060e9a8d912e432202afc2
   depends:
@@ -6276,12 +4985,7 @@ packages:
   - pkg:pypi/six?source=conda-forge-mapping
   size: 14259
   timestamp: 1620240338595
-- kind: conda
-  name: sourmash-minimal
-  version: 4.8.10
-  build: py310h0c3ebd1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sourmash-minimal-4.8.10-py310h0c3ebd1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sourmash-minimal-4.8.10-py310h0c3ebd1_0.conda
   sha256: c447a1ed1166029e4d84e4489ed4e461c0545fc74290979caadbe34736d6a5de
   md5: de91d7bfb4afc30334bf33b74fe6d4ad
   depends:
@@ -6303,12 +5007,7 @@ packages:
   - pkg:pypi/sourmash?source=conda-forge-mapping
   size: 16117828
   timestamp: 1719702913056
-- kind: conda
-  name: sourmash-minimal
-  version: 4.8.10
-  build: py310hee77cae_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/sourmash-minimal-4.8.10-py310hee77cae_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sourmash-minimal-4.8.10-py310hee77cae_0.conda
   sha256: 3128a8487c12b998e16196988724b3809278f44a6d068cfc9e029e7019eba8b7
   md5: 1cf80ef4f90e7f7ac12a44f02bb8d491
   depends:
@@ -6333,15 +5032,14 @@ packages:
   - pkg:pypi/sourmash?source=conda-forge-mapping
   size: 15305588
   timestamp: 1719702888084
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/9b/ab/69df806d3d695ac3e6ad1af884ddfa80ef8a9d2c73d49279464c989a55ac/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   name: sqlalchemy
   version: 2.0.31
-  url: https://files.pythonhosted.org/packages/9b/ab/69df806d3d695ac3e6ad1af884ddfa80ef8a9d2c73d49279464c989a55ac/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
   sha256: f3ad7f221d8a69d32d197e5968d798217a4feebe30144986af71ada8c548e9fa
   requires_dist:
   - typing-extensions>=4.6.0
-  - greenlet!=0.4.17 ; python_version < '3.13' and (platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32'))))))
-  - importlib-metadata ; python_version < '3.8'
+  - greenlet!=0.4.17 ; (python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'WIN32') or (python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version < '3.13' and platform_machine == 'amd64') or (python_full_version < '3.13' and platform_machine == 'ppc64le') or (python_full_version < '3.13' and platform_machine == 'win32') or (python_full_version < '3.13' and platform_machine == 'x86_64')
+  - importlib-metadata ; python_full_version < '3.8'
   - greenlet!=0.4.17 ; extra == 'aiomysql'
   - aiomysql>=0.2.0 ; extra == 'aiomysql'
   - greenlet!=0.4.17 ; extra == 'aioodbc'
@@ -6351,8 +5049,8 @@ packages:
   - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
   - greenlet!=0.4.17 ; extra == 'asyncio'
   - greenlet!=0.4.17 ; extra == 'asyncmy'
-  - asyncmy!=0.2.4,!=0.2.6,>=0.2.3 ; extra == 'asyncmy'
-  - mariadb!=1.1.2,!=1.1.5,>=1.0.1 ; extra == 'mariadb-connector'
+  - asyncmy>=0.2.3,!=0.2.4,!=0.2.6 ; extra == 'asyncmy'
+  - mariadb>=1.0.1,!=1.1.2,!=1.1.5 ; extra == 'mariadb-connector'
   - pyodbc ; extra == 'mssql'
   - pymssql ; extra == 'mssql-pymssql'
   - pyodbc ; extra == 'mssql-pyodbc'
@@ -6372,15 +5070,14 @@ packages:
   - pymysql ; extra == 'pymysql'
   - sqlcipher3-binary ; extra == 'sqlcipher'
   requires_python: '>=3.7'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/bf/90/0ce8c76cd2ef8a5e0838d61d6648a1193859e1990bc1d65c8b0fd1f77ca8/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: sqlalchemy
   version: 2.0.31
-  url: https://files.pythonhosted.org/packages/bf/90/0ce8c76cd2ef8a5e0838d61d6648a1193859e1990bc1d65c8b0fd1f77ca8/SQLAlchemy-2.0.31-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 9f2bee229715b6366f86a95d497c347c22ddffa2c7c96143b59a2aa5cc9eebbc
   requires_dist:
   - typing-extensions>=4.6.0
-  - greenlet!=0.4.17 ; python_version < '3.13' and (platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32'))))))
-  - importlib-metadata ; python_version < '3.8'
+  - greenlet!=0.4.17 ; (python_full_version < '3.13' and platform_machine == 'AMD64') or (python_full_version < '3.13' and platform_machine == 'WIN32') or (python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version < '3.13' and platform_machine == 'amd64') or (python_full_version < '3.13' and platform_machine == 'ppc64le') or (python_full_version < '3.13' and platform_machine == 'win32') or (python_full_version < '3.13' and platform_machine == 'x86_64')
+  - importlib-metadata ; python_full_version < '3.8'
   - greenlet!=0.4.17 ; extra == 'aiomysql'
   - aiomysql>=0.2.0 ; extra == 'aiomysql'
   - greenlet!=0.4.17 ; extra == 'aioodbc'
@@ -6390,8 +5087,8 @@ packages:
   - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
   - greenlet!=0.4.17 ; extra == 'asyncio'
   - greenlet!=0.4.17 ; extra == 'asyncmy'
-  - asyncmy!=0.2.4,!=0.2.6,>=0.2.3 ; extra == 'asyncmy'
-  - mariadb!=1.1.2,!=1.1.5,>=1.0.1 ; extra == 'mariadb-connector'
+  - asyncmy>=0.2.3,!=0.2.4,!=0.2.6 ; extra == 'asyncmy'
+  - mariadb>=1.0.1,!=1.1.2,!=1.1.5 ; extra == 'mariadb-connector'
   - pyodbc ; extra == 'mssql'
   - pymssql ; extra == 'mssql-pymssql'
   - pyodbc ; extra == 'mssql-pyodbc'
@@ -6411,12 +5108,7 @@ packages:
   - pymysql ; extra == 'pymysql'
   - sqlcipher3-binary ; extra == 'sqlcipher'
   requires_python: '>=3.7'
-- kind: conda
-  name: sra-tools
-  version: 3.0.10
-  build: h9f5acd7_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/bioconda/linux-64/sra-tools-3.0.10-h9f5acd7_0.tar.bz2
+- conda: https://conda.anaconda.org/bioconda/linux-64/sra-tools-3.0.10-h9f5acd7_0.tar.bz2
   sha256: bb76adfeec0b754d04399a618a8bb251f95cbf29adeb963606bfa82763edee17
   md5: 80a09c41ba74a17523650adf50c28fe7
   depends:
@@ -6433,10 +5125,9 @@ packages:
   purls: []
   size: 78797583
   timestamp: 1703011282643
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
   name: stack-data
   version: 0.6.3
-  url: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
   sha256: d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
   requires_dist:
   - executing>=1.2.0
@@ -6447,36 +5138,13 @@ packages:
   - pygments ; extra == 'tests'
   - littleutils ; extra == 'tests'
   - cython ; extra == 'tests'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl
   name: swagger-ui-bundle
   version: 0.0.9
-  url: https://files.pythonhosted.org/packages/f1/4e/920b2cece4bc0367a60a53dcdb63ad210ea8bfe1fcebb35c6e5f47a69259/swagger_ui_bundle-0.0.9-py3-none-any.whl
   sha256: cea116ed81147c345001027325c1ddc9ca78c1ee7319935c3c75d3669279d575
   requires_dist:
   - jinja2>=2.0
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
-  sha256: 7fa27cc512d3a783f38bd16bbbffc008807372499d5b65d089a8e43bde9db267
-  md5: f75105e0585851f818e0009dd1dde4dc
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  purls: []
-  size: 3351802
-  timestamp: 1695506242997
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: noxft_h4845f30_101
-  build_number: 101
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
   sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
   md5: d453b98d9c83e71da0741bb0ff4d76bc
   depends:
@@ -6487,13 +5155,18 @@ packages:
   purls: []
   size: 3318875
   timestamp: 1699202167581
-- kind: conda
-  name: toml
-  version: 0.10.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+  sha256: 7fa27cc512d3a783f38bd16bbbffc008807372499d5b65d089a8e43bde9db267
+  md5: f75105e0585851f818e0009dd1dde4dc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3351802
+  timestamp: 1695506242997
+- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
   sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
   md5: f832c45a477c78bebd107098db465095
   depends:
@@ -6504,13 +5177,7 @@ packages:
   - pkg:pypi/toml?source=conda-forge-mapping
   size: 18433
   timestamp: 1604308660817
-- kind: conda
-  name: tomli
-  version: 2.0.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
   sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
   md5: 5844808ffab9ebdb694585b50ba02a96
   depends:
@@ -6521,10 +5188,9 @@ packages:
   - pkg:pypi/tomli?source=conda-forge-mapping
   size: 15940
   timestamp: 1644342331069
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
   name: traitlets
   version: 5.14.3
-  url: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
   sha256: b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f
   requires_dist:
   - myst-parser ; extra == 'docs'
@@ -6535,39 +5201,26 @@ packages:
   - pre-commit ; extra == 'test'
   - pytest-mock ; extra == 'test'
   - pytest-mypy-testing ; extra == 'test'
-  - pytest<8.2,>=7.0 ; extra == 'test'
+  - pytest>=7.0,<8.2 ; extra == 'test'
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
   name: typing-extensions
   version: 4.12.2
-  url: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
   sha256: 04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d
   requires_python: '>=3.8'
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl
   name: tzdata
   version: '2024.1'
-  url: https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl
   sha256: 9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252
   requires_python: '>=2'
-- kind: conda
-  name: tzdata
-  version: 2024a
-  build: h0c530f3_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
   sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
   md5: 161081fc7cec0bfda0d86d7cb595f8d8
   license: LicenseRef-Public-Domain
   purls: []
   size: 119815
   timestamp: 1706886945727
-- kind: conda
-  name: unicodedata2
-  version: 15.1.0
-  build: py310h2372a71_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
   sha256: 5ab2f2d4542ba0cc27d222c08ae61706babe7173b0c6dfa748aa37ff2fa9d824
   md5: 72637c58d36d9475fda24700c9796f19
   depends:
@@ -6580,12 +5233,7 @@ packages:
   - pkg:pypi/unicodedata2?source=conda-forge-mapping
   size: 374055
   timestamp: 1695848183607
-- kind: conda
-  name: unicodedata2
-  version: 15.1.0
-  build: py310hb299538_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-15.1.0-py310hb299538_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-15.1.0-py310hb299538_0.conda
   sha256: b403ce58cd9db8aa9cfcbec09a2a3373475da3956d5c6a396f46e24a415b972e
   md5: 2fbbda3ebdf48a3f3f2fb4656115e2e3
   depends:
@@ -6599,13 +5247,7 @@ packages:
   - pkg:pypi/unicodedata2?source=conda-forge-mapping
   size: 373822
   timestamp: 1695848203177
-- kind: conda
-  name: urllib3
-  version: 1.26.19
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
   sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
   md5: 6bb37c314b3cc1515dcf086ffe01c46e
   depends:
@@ -6618,19 +5260,12 @@ packages:
   - pkg:pypi/urllib3?source=conda-forge-mapping
   size: 115125
   timestamp: 1718728467518
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl
   name: vine
   version: 5.1.0
-  url: https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl
   sha256: 40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc
   requires_python: '>=3.6'
-- kind: conda
-  name: wcwidth
-  version: 0.2.13
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
   sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
   md5: 68f0738df502a14213624b288c60c9ad
   depends:
@@ -6641,23 +5276,15 @@ packages:
   - pkg:pypi/wcwidth?source=conda-forge-mapping
   size: 32709
   timestamp: 1704731373922
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/f6/f8/9da63c1617ae2a1dec2fbf6412f3a0cfe9d4ce029eccbda6e1e4258ca45f/Werkzeug-2.2.3-py3-none-any.whl
   name: werkzeug
   version: 2.2.3
-  url: https://files.pythonhosted.org/packages/f6/f8/9da63c1617ae2a1dec2fbf6412f3a0cfe9d4ce029eccbda6e1e4258ca45f/Werkzeug-2.2.3-py3-none-any.whl
   sha256: 56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612
   requires_dist:
   - markupsafe>=2.1.1
   - watchdog ; extra == 'watchdog'
   requires_python: '>=3.7'
-- kind: conda
-  name: wheel
-  version: 0.43.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
   sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
   md5: 0b5293a157c2b5cd513dd1b03d8d3aae
   depends:
@@ -6668,43 +5295,21 @@ packages:
   - pkg:pypi/wheel?source=conda-forge-mapping
   size: 57963
   timestamp: 1711546009410
-- kind: pypi
+- pypi: .
   name: wort
   version: 0.0.2
-  path: .
-  sha256: 73004681f93be3056e0e95eec8fbf8ec24df45a49444ad88e2d258d842a4ec52
+  sha256: af64ad21c99ceb05bf4ec9ad463647bf54c8f949542b91c32fd5d8b257df5d37
   requires_python: '>=3.10'
   editable: true
-- kind: pypi
+- pypi: https://files.pythonhosted.org/packages/18/19/c3232f35e24dccfad372e9f341c4f3a1166ae7c66e4e1351a9467c921cc1/wtforms-3.1.2-py3-none-any.whl
   name: wtforms
   version: 3.1.2
-  url: https://files.pythonhosted.org/packages/18/19/c3232f35e24dccfad372e9f341c4f3a1166ae7c66e4e1351a9467c921cc1/wtforms-3.1.2-py3-none-any.whl
   sha256: bf831c042829c8cdbad74c27575098d541d039b1faa74c771545ecac916f2c07
   requires_dist:
   - markupsafe
   - email-validator ; extra == 'email'
   requires_python: '>=3.8'
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
-  sha256: c00a8909e783ba7f4ada7256f0385ae46fc21322f4090fa396c80b4481abd5f4
-  md5: 13de34f69cb73165dbe08c1e9148bedb
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 15380
-  timestamp: 1684638889756
-- kind: conda
-  name: xorg-libxau
-  version: 1.0.11
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
   sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
   md5: 2c80dc38fface310c9bd81b17037fee5
   depends:
@@ -6714,27 +5319,17 @@ packages:
   purls: []
   size: 14468
   timestamp: 1684637984591
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.3
-  build: h3557bc0_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
-  sha256: 2aad9a0b57796170b8fb40317598fd79cfc7ae27fa7fb68c417d815e44499d59
-  md5: a6c9016ae1ca5c47a3603ed4cd65fedd
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
+  sha256: c00a8909e783ba7f4ada7256f0385ae46fc21322f4090fa396c80b4481abd5f4
+  md5: 13de34f69cb73165dbe08c1e9148bedb
   depends:
-  - libgcc-ng >=9.3.0
+  - libgcc-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 19916
-  timestamp: 1610072242320
-- kind: conda
-  name: xorg-libxdmcp
-  version: 1.1.3
-  build: h7f98852_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  size: 15380
+  timestamp: 1684638889756
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
   sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
   md5: be93aabceefa2fac576e971aef407908
   depends:
@@ -6744,12 +5339,17 @@ packages:
   purls: []
   size: 19126
   timestamp: 1610071769228
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
+  sha256: 2aad9a0b57796170b8fb40317598fd79cfc7ae27fa7fb68c417d815e44499d59
+  md5: a6c9016ae1ca5c47a3603ed4cd65fedd
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 19916
+  timestamp: 1610072242320
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
   sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   md5: 2161070d867d1b1204ea749c8eec4ef0
   depends:
@@ -6758,12 +5358,7 @@ packages:
   purls: []
   size: 418368
   timestamp: 1660346797927
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h9cdd2b7_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
   sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
   md5: 83baad393a31d59c20b63ba4da6592df
   depends:
@@ -6772,13 +5367,7 @@ packages:
   purls: []
   size: 440555
   timestamp: 1660348056328
-- kind: conda
-  name: zipp
-  version: 3.19.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
   sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
   md5: 49808e59df5535116f6878b2a820d6f4
   depends:
@@ -6789,13 +5378,7 @@ packages:
   - pkg:pypi/zipp?source=conda-forge-mapping
   size: 20917
   timestamp: 1718013395428
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: h4ab18f5_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
   sha256: 534824ea44939f3e59ca8ebb95e3ece6f50f9d2a0e69999fbc692311252ed6ac
   md5: 559d338a4234c2ad6e676f460a093e67
   depends:
@@ -6806,29 +5389,7 @@ packages:
   purls: []
   size: 92883
   timestamp: 1716874088980
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: h02f22dd_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
-  sha256: 484f9d0722c77685ae379fbff3ccd662af9ead7e59eb39cd6d0c677cdf25ff6c
-  md5: be8d5f8cf21aed237b8b182ea86b3dd6
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 539937
-  timestamp: 1714723130243
-- kind: conda
-  name: zstd
-  version: 1.5.6
-  build: ha6fb4c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
   sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
   md5: 4d056880988120e29d75bfff282e0f45
   depends:
@@ -6840,3 +5401,15 @@ packages:
   purls: []
   size: 554846
   timestamp: 1714722996770
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+  sha256: 484f9d0722c77685ae379fbff3ccd662af9ead7e59eb39cd6d0c677cdf25ff6c
+  md5: be8d5f8cf21aed237b8b182ea86b3dd6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 539937
+  timestamp: 1714723130243

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ redis = ">=4.5.5,<4.6"
 flask-wtf = ">=1.1.1,<1.2"
 flask-migrate = ">=4.0.4,<4.1"
 flask-login = ">=0.6.2,<0.7"
+flask-shell-ipython = ">=0.5.1,<0.6"
 jsonschema = ">=4.17.3,<4.18"
 openapi-spec-validator = ">=0.5.7,<0.6"
 sentry-sdk = { version = ">=2.10.0,<2.11.0", extras = ["flask", "celery", "sqlalchemy"] }
@@ -47,7 +48,6 @@ pip = "*"
 
 [tool.pixi.feature.dev.pypi-dependencies]
 biopython = ">=1.81,<2"
-flask-shell-ipython = ">=0.5.1,<0.6"
 pandas = ">=2.0.3,<2.1"
 wort = { path = ".", editable = true }
 

--- a/wort/api.yaml
+++ b/wort/api.yaml
@@ -23,6 +23,7 @@ paths:
         - token: []
       parameters:
         - $ref: '#/components/parameters/sra_id'
+        - $ref: '#/components/parameters/recompute'
       responses:
         '202':
           description: Compute task accepted
@@ -134,3 +135,13 @@ components:
       required: true
       schema:
         type: string
+
+    recompute:
+      name: recompute
+      description: force recompute of already existing dataset
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: false
+

--- a/wort/app.py
+++ b/wort/app.py
@@ -96,7 +96,7 @@ def create_app(settings_override=None):
             # Not in cache, let's check DB
             dataset = Dataset.query.filter_by(id=dataset_id).first()
 
-            if dataset is not None:
+            if dataset is not None and dataset.computed:
                 # Found a hit in DB
                 dataset_info = {}
                 dataset_info["name"] = dataset_id.upper()

--- a/wort/blueprints/compute/views.py
+++ b/wort/blueprints/compute/views.py
@@ -36,6 +36,7 @@ def compute_sra(sra_id, recompute=False):
         dataset.computed = None
         db.session.add(dataset)
         db.session.commit()
+        current_app.cache.delete(f"sra/{sra_id}")
 
     # Not computed yet, send to proper queue
     if dataset.size_MB <= 300:

--- a/wort/blueprints/compute/views.py
+++ b/wort/blueprints/compute/views.py
@@ -1,6 +1,4 @@
 import csv
-import os
-from pathlib import Path
 
 from flask import Blueprint, current_app, jsonify, render_template, url_for
 import requests
@@ -42,7 +40,7 @@ def compute_sra(sra_id, recompute=False):
             conn = boto3.client("s3")
             s3 = boto3.resource("s3")
 
-            key_path = Path("sigs") / f"{sra_id}.sig"
+            key_path = f"sigs/{sra_id}.sig"
             try:
                 obj = s3.Object("wort-sra", key_path)
                 obj.load()


### PR DESCRIPTION
On worker: if the signature is empty, don't upload it to S3, and raise an error for debugging why it failed.

On frontend: Add a `recompute` flag to clean cache and `computed` field from DB. This doesn't delete any existing objects from S3, still need to do this outside `wort`.

Clean up logic for verifying if a dataset is already computed, and only set cache if it is actually computed.

Part of addressing #76 